### PR TITLE
 Fix: cannot switch when fast is hang in auto mode

### DIFF
--- a/adapters/outbound/urltest.go
+++ b/adapters/outbound/urltest.go
@@ -41,7 +41,7 @@ func (u *URLTest) Now() string {
 func (u *URLTest) Generator(metadata *C.Metadata) (adapter C.ProxyAdapter, err error) {
 	a, err := u.fast.Generator(metadata)
 	if err != nil {
-		u.speedTest()
+		go u.speedTest()
 	}
 	return a, err
 }


### PR DESCRIPTION
目前这个方案比较完善，不过还可能存在一种情况，就是speedTest在tick启动了，然后出现错误了，又会在connErr case中再启动一次。 
1. 之前想过用sync.once只能运行一个speedTest,但是一旦这样，就很难reset了。
2. 如果直接用锁也是可以实现的，不过感觉效率不高。

你再帮忙看下还有什么问题不？