### PR TITLE
Fix: goroutine leak while closing proxy

### DIFF
--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -14,21 +14,25 @@ var (
 	tun = tunnel.Instance()
 )
 
-func NewHttpProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
+type httpListener struct {
+	net.Listener
+	address string
+	closed  bool
+}
+
+func NewHttpProxy(addr string) (*httpListener, error) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	done := make(chan struct{})
-	closed := make(chan struct{})
+	hl := &httpListener{l, addr, false}
 
 	go func() {
 		log.Infoln("HTTP proxy listening at: %s", addr)
 		for {
-			c, err := l.Accept()
+			c, err := hl.Accept()
 			if err != nil {
-				if _, open := <-done; !open {
+				if hl.closed {
 					break
 				}
 				continue
@@ -37,14 +41,16 @@ func NewHttpProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
 		}
 	}()
 
-	go func() {
-		<-done
-		close(done)
-		l.Close()
-		closed <- struct{}{}
-	}()
+	return hl, nil
+}
 
-	return done, closed, nil
+func (l *httpListener) Close() {
+	l.Close()
+	l.closed = false
+}
+
+func (l *httpListener) Address() string {
+	return l.address
 }
 
 func handleConn(conn net.Conn) {

--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -39,6 +39,7 @@ func NewHttpProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
 
 	go func() {
 		<-done
+		close(done)
 		l.Close()
 		closed <- struct{}{}
 	}()

--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -45,8 +45,8 @@ func NewHttpProxy(addr string) (*httpListener, error) {
 }
 
 func (l *httpListener) Close() {
-	l.Close()
-	l.closed = false
+	l.closed = true
+	l.Listener.Close()
 }
 
 func (l *httpListener) Address() string {

--- a/proxy/redir/tcp.go
+++ b/proxy/redir/tcp.go
@@ -38,6 +38,7 @@ func NewRedirProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
 
 	go func() {
 		<-done
+		close(done)
 		l.Close()
 		closed <- struct{}{}
 	}()

--- a/proxy/redir/tcp.go
+++ b/proxy/redir/tcp.go
@@ -44,8 +44,8 @@ func NewRedirProxy(addr string) (*redirListener, error) {
 }
 
 func (l *redirListener) Close() {
-	l.Close()
-	l.closed = false
+	l.closed = true
+	l.Listener.Close()
 }
 
 func (l *redirListener) Address() string {

--- a/proxy/redir/tcp.go
+++ b/proxy/redir/tcp.go
@@ -13,21 +13,25 @@ var (
 	tun = tunnel.Instance()
 )
 
-func NewRedirProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
+type redirListener struct {
+	net.Listener
+	address string
+	closed  bool
+}
+
+func NewRedirProxy(addr string) (*redirListener, error) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	done := make(chan struct{})
-	closed := make(chan struct{})
+	rl := &redirListener{l, addr, false}
 
 	go func() {
 		log.Infof("Redir proxy listening at: %s", addr)
 		for {
 			c, err := l.Accept()
 			if err != nil {
-				if _, open := <-done; !open {
+				if rl.closed {
 					break
 				}
 				continue
@@ -36,14 +40,16 @@ func NewRedirProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
 		}
 	}()
 
-	go func() {
-		<-done
-		close(done)
-		l.Close()
-		closed <- struct{}{}
-	}()
+	return rl, nil
+}
 
-	return done, closed, nil
+func (l *redirListener) Close() {
+	l.Close()
+	l.closed = false
+}
+
+func (l *redirListener) Address() string {
+	return l.address
 }
 
 func handleRedir(conn net.Conn) {

--- a/proxy/socks/tcp.go
+++ b/proxy/socks/tcp.go
@@ -45,8 +45,8 @@ func NewSocksProxy(addr string) (*sockListener, error) {
 }
 
 func (l *sockListener) Close() {
-	l.Close()
-	l.closed = false
+	l.closed = true
+	l.Listener.Close()
 }
 
 func (l *sockListener) Address() string {

--- a/proxy/socks/tcp.go
+++ b/proxy/socks/tcp.go
@@ -14,21 +14,25 @@ var (
 	tun = tunnel.Instance()
 )
 
-func NewSocksProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
+type sockListener struct {
+	net.Listener
+	address string
+	closed  bool
+}
+
+func NewSocksProxy(addr string) (*sockListener, error) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	done := make(chan struct{})
-	closed := make(chan struct{})
-
+	sl := &sockListener{l, addr, false}
 	go func() {
 		log.Infof("SOCKS proxy listening at: %s", addr)
 		for {
 			c, err := l.Accept()
 			if err != nil {
-				if _, open := <-done; !open {
+				if sl.closed {
 					break
 				}
 				continue
@@ -37,14 +41,16 @@ func NewSocksProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
 		}
 	}()
 
-	go func() {
-		<-done
-		close(done)
-		l.Close()
-		closed <- struct{}{}
-	}()
+	return sl, nil
+}
 
-	return done, closed, nil
+func (l *sockListener) Close() {
+	l.Close()
+	l.closed = false
+}
+
+func (l *sockListener) Address() string {
+	return l.address
 }
 
 func handleSocks(conn net.Conn) {

--- a/proxy/socks/tcp.go
+++ b/proxy/socks/tcp.go
@@ -39,6 +39,7 @@ func NewSocksProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
 
 	go func() {
 		<-done
+		close(done)
 		l.Close()
 		closed <- struct{}{}
 	}()


### PR DESCRIPTION
测试程序如下：
```golang
package main

import (
	"fmt"
	"net"
	"runtime"
	"time"

	"github.com/Dreamacro/clash/log"
)

func countGoRoutines() int {
	return runtime.NumGoroutine()
}

type listener struct {
	Address string
	Done    chan<- struct{}
	Closed  <-chan struct{}
}

func NewHttpProxy(addr string) (chan<- struct{}, <-chan struct{}, error) {
	l, err := net.Listen("tcp", addr)
	if err != nil {
		return nil, nil, err
	}

	done := make(chan struct{})
	closed := make(chan struct{})

	go func() {
		log.Infoln("HTTP proxy listening at: %s", addr)
		for {
			_, err := l.Accept()
			if err != nil {
				if _, open := <-done; !open {
					break
				}
				continue
			}
			//go handleConn(c)
		}
	}()

	go func() {
		<-done
		close(done)
		l.Close()
		closed <- struct{}{}
		fmt.Printf("HTTP proxy close: %s\n", addr)
	}()

	return done, closed, nil
}

func main() {

	for i := 0; i < 5; i++ {
		done, close, _ := NewHttpProxy("127.0.0.1:12345")
		httplisten1 := &listener{
			Address: "127.0.0.1:12345",
			Done:    done,
			Closed:  close,
		}
		time.Sleep(1 * time.Second)

		httplisten1.Done <- struct{}{}
		<-httplisten1.Closed
		httplisten1 = nil
	}

	time.Sleep(2 * time.Second)
	fmt.Println("last:", countGoRoutines())
}
```
如果注释掉`close(done)`的运行结果如下：
```
INFO[0000] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
INFO[0001] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
INFO[0002] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
INFO[0003] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
INFO[0004] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
last: 7
```
加上`close(done)`的运行结果如下：
```
INFO[0000] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
INFO[0001] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
INFO[0002] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
INFO[0003] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
INFO[0004] HTTP proxy listening at: 127.0.0.1:12345
HTTP proxy close: 127.0.0.1:12345
last: 2
```