### PR TITLE
fix: path.IsAbs is not implemented for windows, use filepath.IsAbs instead

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 	"flag"
 	"path"
+	"path/filepath"
 
 	"github.com/Dreamacro/clash/config"
 	"github.com/Dreamacro/clash/hub"
@@ -31,7 +32,7 @@ func main() {
 	hub.Run()
 
 	if (homedir != "") {
-		if !path.IsAbs(homedir) {
+		if !filepath.IsAbs(homedir) {
 			currentDir, _ := os.Getwd()
 			homedir = path.Join(currentDir, homedir)
 		}


### PR DESCRIPTION
On windows: `path.IsAbs("D:/clash")` returns false.

Refer to: https://github.com/golang/go/issues/1483