### PR TITLE
Fix: don't keepalive when connection is close

### DIFF
--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -25,6 +25,10 @@ func (t *Tunnel) handleHTTP(request *adapters.HTTPAdapter, proxy C.ProxyAdapter)
 	conn := newTrafficTrack(proxy.Conn(), t.traffic)
 	req := request.R
 	host := req.Host
+	keepalive := true
+	if req.Header.Get("Connection") == "close" {
+		keepalive = false
+	}
 
 	for {
 		req.Header.Set("Connection", "close")
@@ -50,6 +54,10 @@ func (t *Tunnel) handleHTTP(request *adapters.HTTPAdapter, proxy C.ProxyAdapter)
 		}
 		err = resp.Write(request.Conn())
 		if err != nil || resp.Close {
+			break
+		}
+
+		if !keepalive {
 			break
 		}
 

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -27,11 +27,12 @@ func (t *Tunnel) handleHTTP(request *adapters.HTTPAdapter, proxy C.ProxyAdapter)
 	req := request.R
 	host := req.Host
 	keepalive := true
-	if strings.ToLower(req.Header.Get("Connection")) == "close" {
-		keepalive = false
-	}
 
 	for {
+		if strings.ToLower(req.Header.Get("Connection")) == "close" {
+			keepalive = false
+		}
+
 		req.Header.Set("Connection", "close")
 		req.RequestURI = ""
 		adapters.RemoveHopByHopHeaders(req.Header)

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,7 +27,7 @@ func (t *Tunnel) handleHTTP(request *adapters.HTTPAdapter, proxy C.ProxyAdapter)
 	req := request.R
 	host := req.Host
 	keepalive := true
-	if req.Header.Get("Connection") == "close" {
+	if strings.ToLower(req.Header.Get("Connection")) == "close" {
 		keepalive = false
 	}
 


### PR DESCRIPTION
目前有些客户端比较笨，比如php的file_get_contents，他不能主动判断http 的keep-alive，一般的正确做法是，php先获取到content-length,然后判断获取到的内容和content-length一样长，就输出内容，而不是一直等。php 的curl库就会自动判断，所以不会卡住。

但是一般客户端有时会传"connection":"close"的头部，就是说不与服务端保持长连接，这里clash的代理应该也不保持长连接，目前nginx的proxy也是会判断这个头部，然后nginx自动断开长连接.

#60 