### PR TITLE
Feat: cache the relation of host and proxy

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	RuleCacheLifeSeconds   = 600
-	RuleCacheExpireSeconds = 120
+	CacheExpireSeconds = 1200
+	CacheCheckSeconds  = 120
 )
 
 var (
@@ -58,7 +58,7 @@ func (t *Tunnel) UpdateRules(rules []C.Rule) {
 	t.configLock.Lock()
 	t.rules = rules
 	// flush rule cache
-	t.cache = cache.New(RuleCacheExpireSeconds * time.Second)
+	t.cache = cache.New(CacheCheckSeconds * time.Second)
 	t.configLock.Unlock()
 }
 
@@ -173,12 +173,12 @@ func (t *Tunnel) match(metadata *C.Metadata) C.Proxy {
 				continue
 			}
 			log.Infoln("%v match %s using %s", key, rule.RuleType().String(), rule.Adapter())
-			t.cache.Put(key, a, RuleCacheLifeSeconds*time.Second)
+			t.cache.Put(key, a, CacheExpireSeconds*time.Second)
 			return a
 		}
 	}
 	log.Infoln("%v doesn't match any rule using DIRECT", key)
-	t.cache.Put(key, t.proxies["DIRECT"], RuleCacheLifeSeconds*time.Second)
+	t.cache.Put(key, t.proxies["DIRECT"], CacheExpireSeconds*time.Second)
 	return t.proxies["DIRECT"]
 }
 
@@ -189,7 +189,7 @@ func newTunnel() *Tunnel {
 		configLock: &sync.RWMutex{},
 		traffic:    C.NewTraffic(time.Second),
 		mode:       Rule,
-		cache:      cache.New(RuleCacheExpireSeconds * time.Second),
+		cache:      cache.New(CacheCheckSeconds * time.Second),
 	}
 }
 


### PR DESCRIPTION
1. 从访问日志看, 重复的网站还是非常多的，如果将网站或者ip与对应的proxy缓存起来，这样就不用每次去匹配规则了
2. 配置里面的规则改动的比较少，所以缓存时间可以设置长一些
3. 不过也有一点代价，就是内存会占用多一些。目前来看20分钟访问的域名并不会很多，可以接受。
```
2018/12/15 18:37:53:897  [info] www.google-analytics.com match DomainKeyword using Proxy
2018/12/15 18:37:54:138  [info] camo.githubusercontent.com match DomainKeyword using Proxy
2018/12/15 18:37:54:144  [info] camo.githubusercontent.com match DomainKeyword using Proxy
2018/12/15 18:37:54:166  [info] camo.githubusercontent.com match DomainKeyword using Proxy
2018/12/15 18:37:54:293  [info] camo.githubusercontent.com match DomainKeyword using Proxy
2018/12/15 18:37:54:302  [info] api.github.com match DomainKeyword using Proxy
2018/12/15 18:37:54:318  [info] clients4.google.com match DomainKeyword using Proxy
2018/12/15 18:37:54:612  [info] raw.githubusercontent.com match DomainKeyword using Proxy
2018/12/15 18:37:58:134  [info] avatars3.githubusercontent.com match DomainKeyword using Proxy
2018/12/15 18:37:58:641  [info] avatars1.githubusercontent.com match DomainKeyword using Proxy
2018/12/15 18:37:58:793  [info] github.com match DomainKeyword using Proxy
2018/12/15 18:37:58:960  [info] api.github.com match DomainKeyword using Proxy
2018/12/15 18:37:59:545  [info] live.github.com match DomainKeyword using Proxy
2018/12/15 18:37:59:771  [info] avatars1.githubusercontent.com match DomainKeyword using Proxy
2018/12/15 18:38:01:986  [info] collector.githubapp.com match DomainKeyword using Proxy
```