### PR TITLE
Fix: return 400 error when connect to nghttpx

### DIFF
--- a/adapters/outbound/http.go
+++ b/adapters/outbound/http.go
@@ -60,7 +60,7 @@ func (h *Http) shakeHand(metadata *C.Metadata, rw io.ReadWriter) error {
 
 	addr := net.JoinHostPort(metadata.Host, metadata.Port)
 	buf.WriteString("CONNECT " + addr + " HTTP/1.1\r\n")
-	buf.WriteString("Host: " + addr + "\r\n")
+	buf.WriteString("Host: " + metadata.Host + "\r\n")
 	buf.WriteString("Proxy-Connection: Keep-Alive\r\n")
 
 	if h.user != "" && h.pass != "" {

--- a/adapters/outbound/http.go
+++ b/adapters/outbound/http.go
@@ -58,9 +58,9 @@ func (h *Http) shakeHand(metadata *C.Metadata, rw io.ReadWriter) error {
 	var buf bytes.Buffer
 	var err error
 
-	buf.WriteString("CONNECT ")
-	buf.WriteString(net.JoinHostPort(metadata.Host, metadata.Port))
-	buf.WriteString(" HTTP/1.1\r\n")
+	addr := net.JoinHostPort(metadata.Host, metadata.Port)
+	buf.WriteString("CONNECT " + addr + " HTTP/1.1\r\n")
+	buf.WriteString("Host: " + addr + "\r\n")
 	buf.WriteString("Proxy-Connection: Keep-Alive\r\n")
 
 	if h.user != "" && h.pass != "" {


### PR DESCRIPTION
nghttpx会检测Host头部，如果没有头部会返回400错误。

测试过程：
1. nghttpx的配置, 运行命令：`sudo nghttpx --conf=nghttpx.conf`
    ```
    frontend=0.0.0.0,8088;no-tls
    backend=127.0.0.1,8081;;no-tls;proto=http/1.1
    http2-proxy=yes
    ```
2. 支持connect的[http proxy](https://www.flysnow.org/2016/12/24/golang-http-proxy.html), 编译运行，监听在8081端口，也就是nghttpx的backend对应的端口。

3. clash的配置

    ```
    - { name: "http", type: http, server: 127.0.0.1, port: 8088 }
    ```

4. 测试命令`curl https://www.baidu.com -x 127.1:7890`