### PR TITLE
Chore: print log when start dns server failed

### DIFF
--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -45,9 +45,7 @@ func GetGeneral() *config.General {
 func updateDNS(c *config.DNS) {
 	if c.Enable == false {
 		T.Instance().SetResolver(nil)
-		if err := dns.ReCreateServer("", nil); err != nil {
-			log.Errorln("Start DNS server error: %s", err.Error())
-		}
+		dns.ReCreateServer("", nil)
 		return
 	}
 	r := dns.New(dns.Config{

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -45,7 +45,9 @@ func GetGeneral() *config.General {
 func updateDNS(c *config.DNS) {
 	if c.Enable == false {
 		T.Instance().SetResolver(nil)
-		dns.ReCreateServer("", nil)
+		if err := dns.ReCreateServer("", nil); err != nil {
+			log.Errorln("Start DNS server error: %s", err.Error())
+		}
 		return
 	}
 	r := dns.New(dns.Config{
@@ -55,7 +57,9 @@ func updateDNS(c *config.DNS) {
 		EnhancedMode: c.EnhancedMode,
 	})
 	T.Instance().SetResolver(r)
-	dns.ReCreateServer(c.Listen, r)
+	if err := dns.ReCreateServer(c.Listen, r); err != nil {
+		log.Errorln("Start DNS server error: %s", err.Error())
+	}
 }
 
 func updateProxies(proxies map[string]C.Proxy) {


### PR DESCRIPTION
当dns启动失败时没有错误信息，比较难排查是哪里的问题。

输出错误日志便于查询问题。