### PR TITLE
Allow arbitrary order in ProxyGroup, loop detect, and autosort ProxyGroup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -293,7 +293,7 @@ func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 	}
 
 	// parse proxy group
-	if err := ProxyGroupsDagSort(groupsConfig); err != nil {
+	if err := proxyGroupsDagSort(groupsConfig); err != nil {
 		return nil, err
 	}
 	for idx, mapping := range groupsConfig {

--- a/config/config.go
+++ b/config/config.go
@@ -293,10 +293,13 @@ func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 	}
 
 	// parse proxy group
+	if err := ProxyGroupsDagSort(groupsConfig); err != nil {
+		return nil, err
+	}
 	for idx, mapping := range groupsConfig {
 		groupType, existType := mapping["type"].(string)
 		groupName, existName := mapping["name"].(string)
-		if !existType && existName {
+		if !(existType && existName) {
 			return nil, fmt.Errorf("ProxyGroup %d: missing type or name", idx)
 		}
 

--- a/config/utils.go
+++ b/config/utils.go
@@ -37,17 +37,21 @@ func or(pointers ...*int) *int {
 
 // check if ProxyGroups form DAG(Directed Acyclic Graph), and sort all ProxyGroups by dependency order
 // meanwhile, record the original index in the config file
+// if loop is detected, return an error with location of loop
 func ProxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
 
 	type Node struct {
 		indegree int
 		topo     int // Topological order
 		data     map[string]interface{}
+		// `outdegree` and `from` are used in loop locating
+		outdegree int
+		from      []string
 	}
 
 	graph := make(map[string]*Node)
 
-	// build dependency graph
+	// Step 1.1 build dependency graph
 	for idx, mapping := range groupsConfig {
 		mapping["configIdx"] = idx // record original order from configfile
 		groupName, existName := mapping["name"].(string)
@@ -60,7 +64,7 @@ func ProxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
 			}
 			node.data = mapping
 		} else {
-			graph[groupName] = &Node{0, -1, mapping}
+			graph[groupName] = &Node{0, -1, mapping, 0, nil}
 		}
 		proxies, existProxies := mapping["proxies"]
 		if !existProxies {
@@ -71,35 +75,77 @@ func ProxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
 			if node, ex := graph[proxy]; ex {
 				node.indegree += 1
 			} else {
-				graph[proxy] = &Node{1, -1, nil}
+				graph[proxy] = &Node{1, -1, nil, 0, nil}
 			}
 		}
 	}
-	// Topological Sort
-	index := 0
-	for len(graph) != 0 {
-		loopDetected := true
-		for name, node := range graph {
-			if node.indegree == 0 { // no one depend on it
-				if node.data != nil {
-					index += 1
-					groupsConfig[len(groupsConfig)-index] = node.data
-					for _, proxy := range node.data["proxies"].([]interface{}) {
-						child, _ := graph[proxy.(string)]
-						child.indegree -= 1
-					}
+	// Step 1.2 Topological Sort
+	index := 0 // topological index of **ProxyGroup** (ignore Porxy)
+	queue := make([]string, 0)
+	for name, node := range graph { // initialize queue with node.indegree == 0
+		if node.indegree == 0 {
+			queue = append(queue, name)
+		}
+	}
+	for ; len(queue) > 0; queue = queue[1:] { // every element in queue have indegree == 0
+		name := queue[0]
+		node := graph[name]
+		if node.data != nil {
+			index += 1
+			groupsConfig[len(groupsConfig)-index] = node.data
+			for _, proxy := range node.data["proxies"].([]interface{}) {
+				child, _ := graph[proxy.(string)]
+				child.indegree -= 1
+				if child.indegree == 0 {
+					queue = append(queue, proxy.(string))
 				}
-				delete(graph, name)
-				loopDetected = false
-				break
 			}
 		}
-		if loopDetected {
-			// TODO: Tell user where the loop occurs
-			// We can locate the loop if we use the reversed graph
-			return fmt.Errorf("Loop detected in ProxyGroup")
-		}
+		delete(graph, name)
 	}
 
-	return nil
+	// no loop detected, return sorted ProxyGroup
+	if len(graph) == 0 {
+		return nil
+	}
+
+	// if loop is detected, locate the loop and throw an error
+	// Step 2.1 rebuild the graph, fill `outdegree` and `from` filed
+	for name, node := range graph {
+		if node.data == nil {
+			continue
+		}
+		for _, proxy := range node.data["proxies"].([]interface{}) {
+			node.outdegree += 1
+			child, _ := graph[proxy.(string)]
+			if child.from == nil {
+				child.from = make([]string, 0, child.indegree)
+			}
+			child.from = append(child.from, name)
+		}
+	}
+	// Step 2.2 remove nodes outside loop
+	queue = make([]string, 0)
+	for name, node := range graph { // initialize queue with node.outdegree == 0
+		if node.outdegree == 0 {
+			queue = append(queue, name)
+		}
+	}
+	for ; len(queue) > 0; queue = queue[1:] { // every element in queue have outdegree == 0
+		name := queue[0]
+		node := graph[name]
+		for _, f := range node.from {
+			graph[f].outdegree -= 1
+			if graph[f].outdegree == 0 {
+				queue = append(queue, f)
+			}
+		}
+		delete(graph, name)
+	}
+	// Step 2.3 report the elements in loop
+	loop_elements := make([]string, 0, len(graph))
+	for name, _ := range graph {
+		loop_elements = append(loop_elements, name)
+	}
+	return fmt.Errorf("Loop detected in ProxyGroup, please check following ProxyGroups: %v", loop_elements)
 }

--- a/config/utils.go
+++ b/config/utils.go
@@ -42,8 +42,9 @@ func proxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
 
 	type Node struct {
 		indegree int
-		// Topological order
+		// topological order
 		topo int
+		// the origional data in `groupsConfig`
 		data map[string]interface{}
 		// `outdegree` and `from` are used in loop locating
 		outdegree int
@@ -54,7 +55,8 @@ func proxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
 
 	// Step 1.1 build dependency graph
 	for idx, mapping := range groupsConfig {
-		// record original order in config file. This field can be used determinate the display order in FrontEnd.
+		// record original order in config file.
+		// this field can be used determinate the display order in FrontEnd.
 		mapping["configIdx"] = idx
 		groupName, existName := mapping["name"].(string)
 		if !existName {
@@ -82,7 +84,7 @@ func proxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
 		}
 	}
 	// Step 1.2 Topological Sort
-	// topological index of **ProxyGroup** (ignore Porxy)
+	// topological index of **ProxyGroup**
 	index := 0
 	queue := make([]string, 0)
 	for name, node := range graph {

--- a/config/utils.go
+++ b/config/utils.go
@@ -34,3 +34,72 @@ func or(pointers ...*int) *int {
 	}
 	return pointers[len(pointers)-1]
 }
+
+// check if ProxyGroups form DAG(Directed Acyclic Graph), and sort all ProxyGroups by dependency order
+// meanwhile, record the original index in the config file
+func ProxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
+
+	type Node struct {
+		indegree int
+		topo     int // Topological order
+		data     map[string]interface{}
+	}
+
+	graph := make(map[string]*Node)
+
+	// build dependency graph
+	for idx, mapping := range groupsConfig {
+		mapping["configIdx"] = idx // record original order from configfile
+		groupName, existName := mapping["name"].(string)
+		if !existName {
+			return fmt.Errorf("ProxyGroup %d: missing name", idx)
+		}
+		if node, ok := graph[groupName]; ok {
+			if node.data != nil {
+				return fmt.Errorf("ProxyGroup %s: the duplicate name", groupName)
+			}
+			node.data = mapping
+		} else {
+			graph[groupName] = &Node{0, -1, mapping}
+		}
+		proxies, existProxies := mapping["proxies"]
+		if !existProxies {
+			return fmt.Errorf("ProxyGroup %s: proxies is requried", groupName)
+		}
+		for _, proxy := range proxies.([]interface{}) {
+			proxy := proxy.(string)
+			if node, ex := graph[proxy]; ex {
+				node.indegree += 1
+			} else {
+				graph[proxy] = &Node{1, -1, nil}
+			}
+		}
+	}
+	// Topological Sort
+	index := 0
+	for len(graph) != 0 {
+		loopDetected := true
+		for name, node := range graph {
+			if node.indegree == 0 { // no one depend on it
+				if node.data != nil {
+					index += 1
+					groupsConfig[len(groupsConfig)-index] = node.data
+					for _, proxy := range node.data["proxies"].([]interface{}) {
+						child, _ := graph[proxy.(string)]
+						child.indegree -= 1
+					}
+				}
+				delete(graph, name)
+				loopDetected = false
+				break
+			}
+		}
+		if loopDetected {
+			// TODO: Tell user where the loop occurs
+			// We can locate the loop if we use the reversed graph
+			return fmt.Errorf("Loop detected in ProxyGroup")
+		}
+	}
+
+	return nil
+}

--- a/config/utils.go
+++ b/config/utils.go
@@ -35,10 +35,8 @@ func or(pointers ...*int) *int {
 	return pointers[len(pointers)-1]
 }
 
-// check if ProxyGroups form DAG(Directed Acyclic Graph), and sort all ProxyGroups by dependency order
-// meanwhile, record the original index in the config file
-// if loop is detected, return an error with location of loop
-func ProxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
+// check if ProxyGroups form DAG(Directed Acyclic Graph), and sort all ProxyGroups by dependency order. meanwhile, record the original index in the config file. if loop is detected, return an error with location of loop.
+func proxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
 
 	type Node struct {
 		indegree int


### PR DESCRIPTION
Check whether `ProxyGroups` forms a DAG(directed acyclic graph), and sort ProxyGroup by their inner dependency relation.

Some user wants to keep the original order of `ProxyGroup` in their config file. This PR only deal with one part of it, the loop detection problem.

function `ProxyGroupsDagSort` build a dependency graph using `rawConfig`, and run **Topological Sorting** on that graph. Then sort all `ProxyGroup` . If a loop is detected, throw an error.
