### PR TITLE
Chore: print origin rule for finding error easily

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -324,7 +324,7 @@ func parseRules(cfg *rawConfig) ([]C.Rule, error) {
 			payload = rule[1]
 			target = rule[2]
 		default:
-			return nil, fmt.Errorf("Rules[%d] error: format invalid", idx)
+			return nil, fmt.Errorf("Rules[%d] [- %s] error: format invalid", idx, line)
 		}
 
 		rule = trimArr(rule)


### PR DESCRIPTION
今天在自己写规则的时候，写错了一个字母，然后报错第80条规则错误，但是配置文件里面有很多注释，找了好久才找到。

如果能在错误信息里面直接输出第80条规则，这样查找错误就非常快。