### PR TITLE
Feature: FROM-IP-CIDR rule type

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Rule:
 - DOMAIN,google.com,Proxy
 - DOMAIN-SUFFIX,ad.com,REJECT
 - IP-CIDR,127.0.0.0/8,DIRECT
+- SOURCE-IP-CIDR,192.168.1.201/32,DIRECT
 - GEOIP,CN,DIRECT
 # FINAL would remove after prerelease
 # you also can use `FINAL,Proxy` or `FINAL,,Proxy` now

--- a/adapters/inbound/http.go
+++ b/adapters/inbound/http.go
@@ -32,8 +32,10 @@ func (h *HTTPAdapter) Conn() net.Conn {
 
 // NewHTTP is HTTPAdapter generator
 func NewHTTP(request *http.Request, conn net.Conn) *HTTPAdapter {
+	metadata := parseHTTPAddr(request)
+	metadata.SourceIP = parseSourceIP(conn)
 	return &HTTPAdapter{
-		metadata: parseHTTPAddr(request),
+		metadata: metadata,
 		R:        request,
 		conn:     conn,
 	}

--- a/adapters/inbound/https.go
+++ b/adapters/inbound/https.go
@@ -7,8 +7,10 @@ import (
 
 // NewHTTPS is HTTPAdapter generator
 func NewHTTPS(request *http.Request, conn net.Conn) *SocketAdapter {
+	metadata := parseHTTPAddr(request)
+	metadata.SourceIP = parseSourceIP(conn)
 	return &SocketAdapter{
-		metadata: parseHTTPAddr(request),
+		metadata: metadata,
 		conn:     conn,
 	}
 }

--- a/adapters/inbound/socket.go
+++ b/adapters/inbound/socket.go
@@ -32,6 +32,7 @@ func (s *SocketAdapter) Conn() net.Conn {
 func NewSocket(target socks.Addr, conn net.Conn, source C.SourceType) *SocketAdapter {
 	metadata := parseSocksAddr(target)
 	metadata.Source = source
+	metadata.SourceIP = parseSourceIP(conn)
 
 	return &SocketAdapter{
 		conn:     conn,

--- a/adapters/inbound/util.go
+++ b/adapters/inbound/util.go
@@ -61,3 +61,10 @@ func parseHTTPAddr(request *http.Request) *C.Metadata {
 
 	return metadata
 }
+
+func parseSourceIP(conn net.Conn) *net.IP {
+	if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		return &addr.IP
+	}
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -338,7 +338,9 @@ func parseRules(cfg *rawConfig) ([]C.Rule, error) {
 		case "GEOIP":
 			rules = append(rules, R.NewGEOIP(payload, target))
 		case "IP-CIDR", "IP-CIDR6":
-			rules = append(rules, R.NewIPCIDR(payload, target))
+			rules = append(rules, R.NewIPCIDR(payload, target, false))
+		case "SOURCE-IP-CIDR":
+			rules = append(rules, R.NewIPCIDR(payload, target, true))
 		case "MATCH":
 			fallthrough
 		case "FINAL":

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -33,6 +33,7 @@ type SourceType int
 type Metadata struct {
 	NetWork  NetWork
 	Source   SourceType
+	SourceIP *net.IP
 	AddrType int
 	Host     string
 	IP       *net.IP

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -7,6 +7,7 @@ const (
 	DomainKeyword
 	GEOIP
 	IPCIDR
+	SourceIPCIDR
 	FINAL
 )
 
@@ -24,6 +25,8 @@ func (rt RuleType) String() string {
 		return "GEOIP"
 	case IPCIDR:
 		return "IPCIDR"
+	case SourceIPCIDR:
+		return "SourceIPCIDR"
 	case FINAL:
 		return "FINAL"
 	default:

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -134,7 +134,7 @@ func (t *Tunnel) handleConn(localConn C.ServerAdapter) {
 	}
 	remoConn, err := proxy.Generator(metadata)
 	if err != nil {
-		log.Warnln("Proxy[%s] connect [%s] error: %s", proxy.Name(), metadata.String(), err.Error())
+		log.Warnln("Proxy[%s] connect [%s --> %s] error: %s", proxy.Name(), metadata.SourceIP.String(), metadata.String(), err.Error())
 		return
 	}
 	defer remoConn.Close()
@@ -157,11 +157,11 @@ func (t *Tunnel) match(metadata *C.Metadata) C.Proxy {
 			if !ok {
 				continue
 			}
-			log.Infoln("%v match %s using %s", metadata.String(), rule.RuleType().String(), rule.Adapter())
+			log.Infoln("%s --> %v match %s using %s", metadata.SourceIP.String(), metadata.String(), rule.RuleType().String(), rule.Adapter())
 			return a
 		}
 	}
-	log.Infoln("%v doesn't match any rule using DIRECT", metadata.String())
+	log.Infoln("%s --> %v doesn't match any rule using DIRECT", metadata.SourceIP.String(), metadata.String())
 	return t.proxies["DIRECT"]
 }
 


### PR DESCRIPTION
When running Clash in router, I want some of my clients to only go through a part of Clash's rules.

Specifically, I don't want my NAS to go through the GeoIP rule, since I run BT downloads in it. 

With this rule type and some changes in the rule sequence, Clash can be more flexible as a redirector in router.