### PR TITLE
Fix: parse host is ip when use socks proxy

### DIFF
--- a/adapters/inbound/util.go
+++ b/adapters/inbound/util.go
@@ -29,10 +29,6 @@ func parseSocksAddr(target socks.Addr) *C.Metadata {
 		metadata.Port = strconv.Itoa((int(target[1+net.IPv6len]) << 8) | int(target[1+net.IPv6len+1]))
 	}
 
-	if len(metadata.Host) > 0 {
-		parseIP(metadata)
-	}
-
 	return metadata
 }
 
@@ -52,19 +48,16 @@ func parseHTTPAddr(request *http.Request) *C.Metadata {
 		Port:     port,
 	}
 
-	parseIP(metadata)
-	return metadata
-}
-
-func parseIP(m *C.Metadata) {
-	ip := net.ParseIP(m.Host)
+	ip := net.ParseIP(host)
 	if ip != nil {
 		switch {
 		case ip.To4() == nil:
-			m.AddrType = C.AtypIPv6
+			metadata.AddrType = C.AtypIPv6
 		default:
-			m.AddrType = C.AtypIPv4
+			metadata.AddrType = C.AtypIPv4
 		}
-		m.IP = &ip
+		metadata.IP = &ip
 	}
+
+	return metadata
 }

--- a/adapters/inbound/util.go
+++ b/adapters/inbound/util.go
@@ -29,6 +29,10 @@ func parseSocksAddr(target socks.Addr) *C.Metadata {
 		metadata.Port = strconv.Itoa((int(target[1+net.IPv6len]) << 8) | int(target[1+net.IPv6len+1]))
 	}
 
+	if len(metadata.Host) > 0 {
+		parseIP(metadata)
+	}
+
 	return metadata
 }
 
@@ -48,16 +52,19 @@ func parseHTTPAddr(request *http.Request) *C.Metadata {
 		Port:     port,
 	}
 
-	ip := net.ParseIP(host)
+	parseIP(metadata)
+	return metadata
+}
+
+func parseIP(m *C.Metadata) {
+	ip := net.ParseIP(m.Host)
 	if ip != nil {
 		switch {
 		case ip.To4() == nil:
-			metadata.AddrType = C.AtypIPv6
+			m.AddrType = C.AtypIPv6
 		default:
-			metadata.AddrType = C.AtypIPv4
+			m.AddrType = C.AtypIPv4
 		}
-		metadata.IP = &ip
+		m.IP = &ip
 	}
-
-	return metadata
 }

--- a/dns/client.go
+++ b/dns/client.go
@@ -148,6 +148,11 @@ func (r *Resolver) resolveIP(m *D.Msg) (msg *D.Msg, err error) {
 }
 
 func (r *Resolver) ResolveIP(host string) (ip net.IP, err error) {
+	ip = net.ParseIP(host)
+	if ip != nil {
+		return ip, nil
+	}
+
 	query := &D.Msg{}
 	dnsType := D.TypeA
 	if r.ipv6 {


### PR DESCRIPTION
修复 #99

测试命令：

```
curl --socks5-hostname 127.1:7891 http://192.168.123.89
```
修复前日志：

```
INFO[0011] 192.168.123.89 match IPCIDR using Proxy
```

修复后日志：

```
INFO[0011] 192.168.123.89 match IPCIDR using  DIRECT
```
