### PR TITLE
Fix: crash when request inboud http directly

### DIFF
--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -41,12 +41,12 @@ type Metadata struct {
 }
 
 func (m *Metadata) String() string {
+	if m.Host == "" && m.IP == nil {
+		return ""
+	}
+
 	if m.Host == "" {
 		return m.IP.String()
 	}
 	return m.Host
-}
-
-func (m *Metadata) Valid() bool {
-	return m.Host != "" || m.IP != nil
 }

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -50,3 +50,7 @@ func (m *Metadata) String() string {
 	}
 	return m.Host
 }
+
+func (m *Metadata) Valid() bool {
+	return m.Host != "" || m.IP != nil
+}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -114,6 +114,10 @@ func (t *Tunnel) needLookupIP(metadata *C.Metadata) bool {
 func (t *Tunnel) handleConn(localConn C.ServerAdapter) {
 	defer localConn.Close()
 	metadata := localConn.Metadata()
+	if !metadata.Valid() {
+		log.Warnln("[Metadata] not valid: %#v", metadata)
+		return
+	}
 
 	if t.needLookupIP(metadata) {
 		host, exist := t.resolver.IPToHost(*metadata.IP)
@@ -136,11 +140,6 @@ func (t *Tunnel) handleConn(localConn C.ServerAdapter) {
 		if err != nil {
 			return
 		}
-	}
-
-	if !metadata.Valid() {
-		log.Warnln("[Metadata] not valid: %#v", metadata)
-		return
 	}
 
 	remoConn, err := proxy.Generator(metadata)

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -114,10 +114,6 @@ func (t *Tunnel) needLookupIP(metadata *C.Metadata) bool {
 func (t *Tunnel) handleConn(localConn C.ServerAdapter) {
 	defer localConn.Close()
 	metadata := localConn.Metadata()
-	if !metadata.Valid() {
-		log.Warnln("[Metadata] not valid: %#v", metadata)
-		return
-	}
 
 	if t.needLookupIP(metadata) {
 		host, exist := t.resolver.IPToHost(*metadata.IP)

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -115,6 +115,11 @@ func (t *Tunnel) handleConn(localConn C.ServerAdapter) {
 	defer localConn.Close()
 	metadata := localConn.Metadata()
 
+	if !metadata.Valid() {
+		log.Warnln("[Metadata] not valid: %#v", metadata)
+		return
+	}
+
 	if t.needLookupIP(metadata) {
 		host, exist := t.resolver.IPToHost(*metadata.IP)
 		if exist {


### PR DESCRIPTION
inbound http代理为： 127.0.0.1:7890
1. `curl -x 127.1:7890 http://github.com`没有问题
2. `curl http://127.0.0.1:7890`, 直接崩溃，log如下：
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x530683]

goroutine 21 [running]:
github.com/Dreamacro/clash/constant.(*Metadata).String(0xc0001f2230, 0x10, 0x10)
        /home/vagrant/devel/clash/constant/metadata.go:45 +0x33
github.com/Dreamacro/clash/tunnel.(*Tunnel).match(0xc0000ae460, 0xc0001f2230, 0x0, 0x0, 0x0, 0x0)
        /home/vagrant/devel/clash/tunnel/tunnel.go:181 +0x3b5
github.com/Dreamacro/clash/tunnel.(*Tunnel).handleConn(0xc0000ae460, 0x8f38a0, 0xc0001f09e0)
        /home/vagrant/devel/clash/tunnel/tunnel.go:135 +0x51c
created by github.com/Dreamacro/clash/tunnel.(*Tunnel).process
        /home/vagrant/devel/clash/tunnel/tunnel.go:93 +0x93
```
3. 如果有些app不遵循http proxy的规则，这样就可能会得到一个空的metadata, 从而导致clashx，cfw...软件直接崩溃退出。