### PR TITLE
support TCP DNS & log the DNS parsing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ external-controller: 127.0.0.1:9090
   #   - 114.114.114.114
   #   - tls://dns.rubyfish.cn:853 # dns over tls
   # fallback: # concurrent request with nameserver, fallback used when GEOIP country isn't CN
-  #   - 8.8.8.8
+  #   - tcp://1.1.1.1
 
 Proxy:
 


### PR DESCRIPTION
- add TCP DNS support in DNS config
- log the DNS config parsing error 

fix #126 