### PR TITLE
Add Headers setting in ss-v2ray-plugin

### DIFF
--- a/adapters/outbound/shadowsocks.go
+++ b/adapters/outbound/shadowsocks.go
@@ -48,11 +48,12 @@ type simpleObfsOption struct {
 }
 
 type v2rayObfsOption struct {
-	Mode           string `obfs:"mode"`
-	Host           string `obfs:"host,omitempty"`
-	Path           string `obfs:"path,omitempty"`
-	TLS            bool   `obfs:"tls,omitempty"`
-	SkipCertVerify bool   `obfs:"skip-cert-verify,omitempty"`
+	Mode           string            `obfs:"mode"`
+	Host           string            `obfs:"host,omitempty"`
+	Path           string            `obfs:"path,omitempty"`
+	TLS            bool              `obfs:"tls,omitempty"`
+	Headers        map[string]string `obfs:"headers,omitempty"`
+	SkipCertVerify bool              `obfs:"skip-cert-verify,omitempty"`
 }
 
 func (ss *ShadowSocks) Generator(metadata *C.Metadata) (net.Conn, error) {
@@ -131,10 +132,10 @@ func NewShadowSocks(option ShadowSocksOption) (*ShadowSocks, error) {
 				ClientSessionCache: getClientSessionCache(),
 			}
 		}
-
 		wsOption = &v2rayObfs.WebsocketOption{
 			Host:      opts.Host,
 			Path:      opts.Path,
+			Headers:   opts.Headers,
 			TLSConfig: tlsConfig,
 		}
 	}

--- a/component/v2ray-plugin/websocket.go
+++ b/component/v2ray-plugin/websocket.go
@@ -11,6 +11,7 @@ import (
 type WebsocketOption struct {
 	Host      string
 	Path      string
+	Headers   map[string]string
 	TLSConfig *tls.Config
 }
 
@@ -20,6 +21,7 @@ func NewWebsocketObfs(conn net.Conn, option *WebsocketOption) (net.Conn, error) 
 		Host:      option.Host,
 		Path:      option.Path,
 		TLS:       option.TLSConfig != nil,
+		Headers:   option.Headers,
 		TLSConfig: option.TLSConfig,
 	}
 


### PR DESCRIPTION
我对v2ray-plugin这里，加上了自定义Headers，

```
 - name: "ss3"
    type: ss
    server: server
    port: 443
    cipher: AEAD_CHACHA20_POLY1305
    password: "password"
    plugin: v2ray-plugin
    plugin-opts:
      mode: websocket 
      headers: { Host: v2ray.com, AVC: bing.com}
```

