### PR TITLE
Increase UDPSize for DNS and add error log for dns service

### DIFF
--- a/dns/client.go
+++ b/dns/client.go
@@ -234,6 +234,7 @@ func transform(servers []NameServer) []*nameserver {
 				TLSConfig: &tls.Config{
 					ClientSessionCache: globalSessionCache,
 				},
+				UDPSize: 4096,
 			},
 			Address: s.Addr,
 		})

--- a/dns/server.go
+++ b/dns/server.go
@@ -1,8 +1,10 @@
 package dns
 
 import (
+	"fmt"
 	"net"
 
+	"github.com/Dreamacro/clash/log"
 	D "github.com/miekg/dns"
 )
 
@@ -20,6 +22,9 @@ func (s *Server) ServeDNS(w D.ResponseWriter, r *D.Msg) {
 	msg, err := s.r.Exchange(r)
 
 	if err != nil {
+		q := r.Question[0]
+		qString := fmt.Sprintf("%s %s %s", q.Name, D.Class(q.Qclass).String(), D.Type(q.Qtype).String())
+		log.Debugln("[DNS Server] Exchange %s failed: %v", qString, err)
 		D.HandleFailed(w, r)
 		return
 	}

--- a/dns/server.go
+++ b/dns/server.go
@@ -22,9 +22,11 @@ func (s *Server) ServeDNS(w D.ResponseWriter, r *D.Msg) {
 	msg, err := s.r.Exchange(r)
 
 	if err != nil {
-		q := r.Question[0]
-		qString := fmt.Sprintf("%s %s %s", q.Name, D.Class(q.Qclass).String(), D.Type(q.Qtype).String())
-		log.Debugln("[DNS Server] Exchange %s failed: %v", qString, err)
+		if len(r.Question) > 0 {
+			q := r.Question[0]
+			qString := fmt.Sprintf("%s %s %s", q.Name, D.Class(q.Qclass).String(), D.Type(q.Qtype).String())
+			log.Debugln("[DNS Server] Exchange %s failed: %v", qString, err)
+		}
 		D.HandleFailed(w, r)
 		return
 	}


### PR DESCRIPTION
Edited, the original title is "Add TCP DNS server"

- Listen TCP port at the same time
- Add err log for DNS server

### Why I create this PR

In some case, the upstream DNS server will return large DNS response, which is larger than a single UDP package. The UDP response will set the `truncated` flag. Most DNS client will try to get the full response through TCP again.

If clash doesn't implement a TCP DNS service, the following error will happen.

```
dig @127.0.0.1 -p 5353 unpkg.zhimg.com 
;; WARNING: truncated reply from 127.0.0.1@5353(UDP), retrying over TCP
;; WARNING: can't connect to 127.0.0.1@5353(TCP)

;; WARNING: truncated reply from 127.0.0.1@5353(UDP), retrying over TCP
;; WARNING: can't connect to 127.0.0.1@5353(TCP)

;; WARNING: truncated reply from 127.0.0.1@5353(UDP), retrying over TCP
;; WARNING: can't connect to 127.0.0.1@5353(TCP)
;; WARNING: failed to query server 127.0.0.1@5353(UDP)
```

And the real response from upstream is like 

```
dig unpkg.zhimg.com @10.10.0.21

; <<>> DiG 9.11.3-1ubuntu1.5-Ubuntu <<>> unpkg.zhimg.com @10.10.0.21
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 29662
;; flags: qr rd ra; QUERY: 1, ANSWER: 16, AUTHORITY: 13, ADDITIONAL: 27

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
; COOKIE: 747311b53b838cf3c37a63885c81d5601817861244871d6c (good)
;; QUESTION SECTION:
;unpkg.zhimg.com. IN A

;; ANSWER SECTION:
unpkg.zhimg.com. 22996 IN A 117.169.80.201
unpkg.zhimg.com. 22996 IN A 117.169.80.203
unpkg.zhimg.com. 22996 IN A 117.169.80.204
unpkg.zhimg.com. 22996 IN A 36.156.81.235
unpkg.zhimg.com. 22996 IN A 117.169.80.202
unpkg.zhimg.com. 22996 IN A 117.169.80.206
unpkg.zhimg.com. 22996 IN A 117.169.80.205
unpkg.zhimg.com. 22996 IN A 117.169.80.198
unpkg.zhimg.com. 22996 IN A 36.156.81.239
unpkg.zhimg.com. 22996 IN A 36.156.81.236
unpkg.zhimg.com. 22996 IN A 36.156.81.234
unpkg.zhimg.com. 22996 IN A 36.156.81.238
unpkg.zhimg.com. 22996 IN A 36.156.81.237
unpkg.zhimg.com. 22996 IN A 117.169.80.199
unpkg.zhimg.com. 22996 IN A 36.156.81.233
unpkg.zhimg.com. 22996 IN A 36.156.81.240

;; AUTHORITY SECTION:
. 17259 IN NS i.root-servers.net.
. 17259 IN NS g.root-servers.net.
. 17259 IN NS b.root-servers.net.
. 17259 IN NS l.root-servers.net.
. 17259 IN NS f.root-servers.net.
. 17259 IN NS k.root-servers.net.
. 17259 IN NS c.root-servers.net.
. 17259 IN NS m.root-servers.net.
. 17259 IN NS j.root-servers.net.
. 17259 IN NS h.root-servers.net.
. 17259 IN NS a.root-servers.net.
. 17259 IN NS e.root-servers.net.
. 17259 IN NS d.root-servers.net.

;; ADDITIONAL SECTION:
a.root-servers.net. 281571 IN A 198.41.0.4
b.root-servers.net. 281568 IN A 199.9.14.201
c.root-servers.net. 281568 IN A 192.33.4.12
d.root-servers.net. 281568 IN A 199.7.91.13
e.root-servers.net. 231341 IN A 192.203.230.10
f.root-servers.net. 211836 IN A 192.5.5.241
g.root-servers.net. 281568 IN A 192.112.36.4
h.root-servers.net. 281568 IN A 198.97.190.53
i.root-servers.net. 281568 IN A 192.36.148.17
j.root-servers.net. 281568 IN A 192.58.128.30
k.root-servers.net. 281568 IN A 193.0.14.129
l.root-servers.net. 281568 IN A 199.7.83.42
m.root-servers.net. 281568 IN A 202.12.27.33
a.root-servers.net. 322059 IN AAAA 2001:503:ba3e::2:30
b.root-servers.net. 322058 IN AAAA 2001:500:200::b
c.root-servers.net. 322058 IN AAAA 2001:500:2::c
d.root-servers.net. 322059 IN AAAA 2001:500:2d::d
e.root-servers.net. 322058 IN AAAA 2001:500:a8::e
f.root-servers.net. 322059 IN AAAA 2001:500:2f::f
g.root-servers.net. 322058 IN AAAA 2001:500:12::d0d
h.root-servers.net. 322058 IN AAAA 2001:500:1::53
i.root-servers.net. 322058 IN AAAA 2001:7fe::53
j.root-servers.net. 322059 IN AAAA 2001:503:c27::2:30
k.root-servers.net. 322059 IN AAAA 2001:7fd::1
l.root-servers.net. 322058 IN AAAA 2001:500:9f::42
m.root-servers.net. 322059 IN AAAA 2001:dc3::35

;; Query time: 13 msec
;; SERVER: 10.10.0.21#53(10.10.0.21)
;; WHEN: Fri Mar 08 10:37:20 CST 2019
;; MSG SIZE rcvd: 1111
```
 
