### PR TITLE
using fallback dns for reserved address

### DIFF
--- a/dns/client.go
+++ b/dns/client.go
@@ -131,7 +131,7 @@ func (r *Resolver) resolveIP(m *D.Msg) (msg *D.Msg, err error) {
 		}
 
 		if ips := r.msgToIP(res.Msg); len(ips) != 0 {
-			if record, _ := mmdb.Country(ips[0]); record.Country.IsoCode == "CN" || record.Country.IsoCode == "" {
+			if record, _ := mmdb.Country(ips[0]); record.Country.IsoCode == "CN" {
 				// release channel
 				go func() { <-fallbackMsg }()
 				msg = res.Msg


### PR DESCRIPTION
```
The IP address '243.185.187.39' is a reserved IP address (private, multicast, etc.).
```
This IP will make Chrome shows Error like https://github.com/Dreamacro/clash/issues/103

So when got a reversed IP that isoCode is empty, use fallback dns instead.