### PR TITLE
 New feature: add support for SO_MARK for Linux socket options

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ external-controller: 127.0.0.1:9090
 # Secret for RESTful API (Optional)
 # secret: ""
 
+# SO_MARK for Linux socket options which may help filter and bypass outbound packet processed by clash
+# in order to build a transparent proxy together with Netfilter redirect
+# socket-mark: 0xffff
+
 # dns:
   # enable: true # set true to enable dns (default is false)
   # ipv6: false # default is false

--- a/adapters/outbound/direct.go
+++ b/adapters/outbound/direct.go
@@ -16,7 +16,7 @@ func (d *Direct) Dial(metadata *C.Metadata) (net.Conn, error) {
 		address = net.JoinHostPort(metadata.IP.String(), metadata.Port)
 	}
 
-	c, err := net.DialTimeout("tcp", address, tcpTimeout)
+	c, err := dialTimeout("tcp", address, tcpTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/outbound/http.go
+++ b/adapters/outbound/http.go
@@ -36,7 +36,7 @@ type HttpOption struct {
 }
 
 func (h *Http) Dial(metadata *C.Metadata) (net.Conn, error) {
-	c, err := net.DialTimeout("tcp", h.addr, tcpTimeout)
+	c, err := dialTimeout("tcp", h.addr, tcpTimeout)
 	if err == nil && h.tls {
 		cc := tls.Client(c, h.tlsConfig)
 		err = cc.Handshake()

--- a/adapters/outbound/shadowsocks.go
+++ b/adapters/outbound/shadowsocks.go
@@ -57,7 +57,7 @@ type v2rayObfsOption struct {
 }
 
 func (ss *ShadowSocks) Dial(metadata *C.Metadata) (net.Conn, error) {
-	c, err := net.DialTimeout("tcp", ss.server, tcpTimeout)
+	c, err := dialTimeout("tcp", ss.server, tcpTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %s", ss.server, err.Error())
 	}

--- a/adapters/outbound/socks5.go
+++ b/adapters/outbound/socks5.go
@@ -35,7 +35,7 @@ type Socks5Option struct {
 }
 
 func (ss *Socks5) Dial(metadata *C.Metadata) (net.Conn, error) {
-	c, err := net.DialTimeout("tcp", ss.addr, tcpTimeout)
+	c, err := dialTimeout("tcp", ss.addr, tcpTimeout)
 
 	if err == nil && ss.tls {
 		cc := tls.Client(c, ss.tlsConfig)

--- a/adapters/outbound/util_darwin.go
+++ b/adapters/outbound/util_darwin.go
@@ -1,0 +1,10 @@
+package adapters
+
+import (
+	"net"
+	"time"
+)
+
+func dialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout(network, address, timeout)
+}

--- a/adapters/outbound/util_freebsd.go
+++ b/adapters/outbound/util_freebsd.go
@@ -1,0 +1,10 @@
+package adapters
+
+import (
+	"net"
+	"time"
+)
+
+func dialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout(network, address, timeout)
+}

--- a/adapters/outbound/util_linux.go
+++ b/adapters/outbound/util_linux.go
@@ -1,0 +1,28 @@
+package adapters
+
+import (
+	"net"
+	"syscall"
+	"time"
+
+	"github.com/Dreamacro/clash/log"
+	T "github.com/Dreamacro/clash/tunnel"
+)
+
+func dialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+	socketMark := T.Instance().SocketMark()
+	if socketMark == 0 {
+		return net.DialTimeout(network, address, timeout)
+	}
+	d := &net.Dialer{
+		Timeout: timeout,
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, socketMark); err != nil {
+					log.Errorln("Set SO_MARK error: %s", err)
+				}
+			})
+		},
+	}
+	return d.Dial(network, address)
+}

--- a/adapters/outbound/util_windows.go
+++ b/adapters/outbound/util_windows.go
@@ -1,0 +1,10 @@
+package adapters
+
+import (
+	"net"
+	"time"
+)
+
+func dialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout(network, address, timeout)
+}

--- a/adapters/outbound/vmess.go
+++ b/adapters/outbound/vmess.go
@@ -31,7 +31,7 @@ type VmessOption struct {
 }
 
 func (v *Vmess) Dial(metadata *C.Metadata) (net.Conn, error) {
-	c, err := net.DialTimeout("tcp", v.server, tcpTimeout)
+	c, err := dialTimeout("tcp", v.server, tcpTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error", v.server)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ type General struct {
 	ExternalController string       `json:"-"`
 	ExternalUI         string       `json:"-"`
 	Secret             string       `json:"-"`
-	SocketMark         int          `json:"socket-mark"`
+	SocketMark         int          `json:"-"`
 }
 
 // DNS config

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type General struct {
 	ExternalController string       `json:"-"`
 	ExternalUI         string       `json:"-"`
 	Secret             string       `json:"-"`
+	SocketMark         int          `json:"socket-mark"`
 }
 
 // DNS config
@@ -70,6 +71,7 @@ type rawConfig struct {
 	ExternalController string       `yaml:"external-controller"`
 	ExternalUI         string       `yaml:"external-ui"`
 	Secret             string       `yaml:"secret"`
+	SocketMark         int          `yaml:"socket-mark"`
 
 	DNS        rawDNS                   `yaml:"dns"`
 	Proxy      []map[string]interface{} `yaml:"Proxy"`
@@ -150,6 +152,7 @@ func parseGeneral(cfg *rawConfig) (*General, error) {
 	externalController := cfg.ExternalController
 	externalUI := cfg.ExternalUI
 	secret := cfg.Secret
+	socketMark := cfg.SocketMark
 	mode := cfg.Mode
 	logLevel := cfg.LogLevel
 
@@ -173,6 +176,7 @@ func parseGeneral(cfg *rawConfig) (*General, error) {
 		ExternalController: externalController,
 		ExternalUI:         externalUI,
 		Secret:             secret,
+		SocketMark:         socketMark,
 	}
 	return general, nil
 }

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -80,6 +80,7 @@ func updateRules(rules []C.Rule) {
 func updateGeneral(general *config.General) {
 	log.SetLevel(general.LogLevel)
 	T.Instance().SetMode(general.Mode)
+	T.Instance().SetSocketMark(general.SocketMark)
 
 	allowLan := general.AllowLan
 

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -30,6 +30,8 @@ type Tunnel struct {
 
 	// Outbound Rule
 	mode Mode
+	// SO_MARK for socket options
+	socketMark int
 }
 
 // Add request to queue
@@ -74,6 +76,16 @@ func (t *Tunnel) Mode() Mode {
 // SetMode change the mode of tunnel
 func (t *Tunnel) SetMode(mode Mode) {
 	t.mode = mode
+}
+
+// SocketMark returns socket option SO_MARK
+func (t *Tunnel) SocketMark() int {
+	return t.socketMark
+}
+
+// SetSocketMark changes socket option SO_MARK
+func (t *Tunnel) SetSocketMark(socketMark int) {
+	t.socketMark = socketMark
 }
 
 // SetResolver change the resolver of tunnel


### PR DESCRIPTION
Thanks to Netfilter TCP redirect, Clash is able to be setup as a transparent proxy.

Let's say we setup Clash on an OpenWrt gateway, redirecting TCP traffic to Clash by Netfilter/iptables, all devices connected to the gateway are proxied automatically and transparently.

Regarding the last mile, the gateway itself, we have to deal with chain OUTPUT just like chain PREROUTING (Inspired by this [article](https://toutyrater.github.io/app/transparent_proxy.html)). At the same time, outbound traffic processed by Clash needs to be bypassed. To bypass specific traffic, we could mark each packet by setting specified SO_MARK socket options within Clash and filter by SO_MARK at chain OUTPUT. Then problem solved.

Note: SO_MARK only works on Linux, but it is enough since most router/gateway operating systems are based on Linux.

### clash config.yml

```
socket-mark: 0xffff
```

### iptables NAT rules

```
iptables -t nat -N CLASH
iptables -t nat -A CLASH -d 127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 -j RETURN
iptables -t nat -A CLASH -p tcp -m mark --mark 0xffff -j RETURN
iptables -t nat -A CLASH -p tcp -j REDIRECT --to-ports 7892
iptables -t nat -A PREROUTING -p tcp -j CLASH
iptables -t nat -A OUTPUT -p tcp -j CLASH
```