### PR TITLE
make the proxies order the same as the order in config file

### DIFF
--- a/adapters/outbound/selector.go
+++ b/adapters/outbound/selector.go
@@ -13,6 +13,7 @@ type Selector struct {
 	*Base
 	selected C.Proxy
 	proxies  map[string]C.Proxy
+	proxyList []string
 }
 
 type SelectorOption struct {
@@ -41,7 +42,7 @@ func (s *Selector) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
 		"type": s.Type().String(),
 		"now":  s.Now(),
-		"all":  all,
+		"all":  s.proxyList,
 	})
 }
 
@@ -64,8 +65,10 @@ func NewSelector(name string, proxies []C.Proxy) (*Selector, error) {
 	}
 
 	mapping := make(map[string]C.Proxy)
-	for _, proxy := range proxies {
+	proxyList := make([]string, len(proxies))
+	for id, proxy := range proxies {
 		mapping[proxy.Name()] = proxy
+		proxyList[id] = proxy.Name()
 	}
 
 	s := &Selector{
@@ -75,6 +78,7 @@ func NewSelector(name string, proxies []C.Proxy) (*Selector, error) {
 		},
 		proxies:  mapping,
 		selected: proxies[0],
+		proxyList: proxyList,
 	}
 	return s, nil
 }

--- a/adapters/outbound/selector.go
+++ b/adapters/outbound/selector.go
@@ -4,15 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
-	"sort"
 
 	C "github.com/Dreamacro/clash/constant"
 )
 
 type Selector struct {
 	*Base
-	selected C.Proxy
-	proxies  map[string]C.Proxy
+	selected  C.Proxy
+	proxies   map[string]C.Proxy
 	proxyList []string
 }
 
@@ -34,11 +33,6 @@ func (s *Selector) SupportUDP() bool {
 }
 
 func (s *Selector) MarshalJSON() ([]byte, error) {
-	var all []string
-	for k := range s.proxies {
-		all = append(all, k)
-	}
-	sort.Strings(all)
 	return json.Marshal(map[string]interface{}{
 		"type": s.Type().String(),
 		"now":  s.Now(),
@@ -66,9 +60,9 @@ func NewSelector(name string, proxies []C.Proxy) (*Selector, error) {
 
 	mapping := make(map[string]C.Proxy)
 	proxyList := make([]string, len(proxies))
-	for id, proxy := range proxies {
+	for idx, proxy := range proxies {
 		mapping[proxy.Name()] = proxy
-		proxyList[id] = proxy.Name()
+		proxyList[idx] = proxy.Name()
 	}
 
 	s := &Selector{
@@ -76,8 +70,8 @@ func NewSelector(name string, proxies []C.Proxy) (*Selector, error) {
 			name: name,
 			tp:   C.Selector,
 		},
-		proxies:  mapping,
-		selected: proxies[0],
+		proxies:   mapping,
+		selected:  proxies[0],
 		proxyList: proxyList,
 	}
 	return s, nil

--- a/config/config.go
+++ b/config/config.go
@@ -194,7 +194,7 @@ func parseGeneral(cfg *rawConfig) (*General, error) {
 
 func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 	proxies := make(map[string]C.Proxy)
-	proxyList := []string{};
+	proxyList := []string{}
 	proxiesConfig := cfg.Proxy
 	groupsConfig := cfg.ProxyGroup
 
@@ -202,7 +202,7 @@ func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 
 	proxies["DIRECT"] = adapters.NewProxy(adapters.NewDirect())
 	proxies["REJECT"] = adapters.NewProxy(adapters.NewReject())
-	proxyList = append(proxyList, "DIRECT","REJECT")
+	proxyList = append(proxyList, "DIRECT", "REJECT")
 
 	// parse proxy
 	for idx, mapping := range proxiesConfig {

--- a/config/config.go
+++ b/config/config.go
@@ -194,6 +194,7 @@ func parseGeneral(cfg *rawConfig) (*General, error) {
 
 func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 	proxies := make(map[string]C.Proxy)
+	proxyList := []string{};
 	proxiesConfig := cfg.Proxy
 	groupsConfig := cfg.ProxyGroup
 
@@ -201,6 +202,7 @@ func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 
 	proxies["DIRECT"] = adapters.NewProxy(adapters.NewDirect())
 	proxies["REJECT"] = adapters.NewProxy(adapters.NewReject())
+	proxyList = append(proxyList, "DIRECT","REJECT")
 
 	// parse proxy
 	for idx, mapping := range proxiesConfig {
@@ -252,6 +254,7 @@ func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 			return nil, fmt.Errorf("Proxy %s is the duplicate name", proxy.Name())
 		}
 		proxies[proxy.Name()] = adapters.NewProxy(proxy)
+		proxyList = append(proxyList, proxy.Name())
 	}
 
 	// parse proxy group
@@ -323,11 +326,12 @@ func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 			return nil, fmt.Errorf("Proxy %s: %s", groupName, err.Error())
 		}
 		proxies[groupName] = adapters.NewProxy(group)
+		proxyList = append(proxyList, groupName)
 	}
 
 	ps := []C.Proxy{}
-	for _, v := range proxies {
-		ps = append(ps, v)
+	for _, v := range proxyList {
+		ps = append(ps, proxies[v])
 	}
 
 	global, _ := adapters.NewSelector("GLOBAL", ps)


### PR DESCRIPTION
the order of proxies and Selector's proxies list are arbitrary, when you have dozens of nodes, it was confusing, I make it the same as the order in the config file and the change will not break up previous versions of web version GUI(http://clash.razord.top). I will create a pull request to clash-dashboard latter.