### PR TITLE
feature: add arguments to specify config file name in config folder

### DIFF
--- a/constant/path.go
+++ b/constant/path.go
@@ -12,7 +12,8 @@ const Name = "clash"
 var Path *path
 
 type path struct {
-	homedir string
+	homedir  string
+	confname string
 }
 
 func init() {
@@ -34,7 +35,17 @@ func init() {
 
 // SetHomeDir is used to set the configuration path
 func SetHomeDir(root string) {
-	Path = &path{homedir: root}
+	Path = &path{
+		homedir:  root,
+		confname: "config.yml",
+	}
+}
+
+func SetHomeDirAndConfName(root string, name string) {
+	Path = &path{
+		homedir:  root,
+		confname: name,
+	}
 }
 
 func (p *path) HomeDir() string {
@@ -42,7 +53,7 @@ func (p *path) HomeDir() string {
 }
 
 func (p *path) Config() string {
-	return P.Join(p.homedir, "config.yml")
+	return P.Join(p.homedir, p.confname)
 }
 
 func (p *path) MMDB() string {

--- a/main.go
+++ b/main.go
@@ -17,12 +17,14 @@ import (
 )
 
 var (
-	version bool
-	homedir string
+	version    bool
+	homedir    string
+	configname string
 )
 
 func init() {
 	flag.StringVar(&homedir, "d", "", "set configuration directory")
+	flag.StringVar(&configname, "c", "", "set configuration file name")
 	flag.BoolVar(&version, "v", false, "show current version of clash")
 	flag.Parse()
 }
@@ -41,7 +43,11 @@ func main() {
 			currentDir, _ := os.Getwd()
 			homedir = filepath.Join(currentDir, homedir)
 		}
-		C.SetHomeDir(homedir)
+		if configname != "" {
+			C.SetHomeDirAndConfName(homedir, configname)
+		} else {
+			C.SetHomeDir(homedir)
+		}
 	}
 
 	if err := config.Init(C.Path.HomeDir()); err != nil {


### PR DESCRIPTION
Add new argument (-c) to specify config file name in config folder.

Could be handy when subscribing from multiple service.