### PR TITLE
Use original sequence for urltest group

### DIFF
--- a/adapters/outbound/urltest.go
+++ b/adapters/outbound/urltest.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -56,7 +55,6 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 	for _, proxy := range u.proxies {
 		all = append(all, proxy.Name())
 	}
-	sort.Strings(all)
 	return json.Marshal(map[string]interface{}{
 		"type": u.Type().String(),
 		"now":  u.Now(),


### PR DESCRIPTION
The urltest outbound is currently sorting alphabetically which is inconsistent with other outbound types. This is to make it work as expected.