### PR TITLE
Optimize: socks UDP & fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ bin/*
 
 # dep
 vendor
+
+# GoLand
+.idea/*
+
+# macOS file
+.DS_Store

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -161,16 +161,16 @@ func (t *Tunnel) handleConn(localConn C.ServerAdapter) {
 func (t *Tunnel) handleUDPConn(localConn C.ServerAdapter, metadata *C.Metadata, proxy C.Proxy, rule C.Rule) {
 	pc, addr := natTable.Get(localConn.RemoteAddr())
 	if pc == nil {
-		rawpc, naddr, err := proxy.DialUDP(metadata)
-		addr = naddr
-		pc = rawpc
+		rawPc, nAddr, err := proxy.DialUDP(metadata)
+		addr = nAddr
+		pc = rawPc
 		if err != nil {
 			log.Warnln("dial %s error: %s", proxy.Name(), err.Error())
 			return
 		}
 
 		if rule != nil {
-			log.Infoln("%s --> %v match %s using %s", metadata.SrcIP.String(), metadata.String(), rule.RuleType().String(), rawpc.Chains().String())
+			log.Infoln("%s --> %v match %s using %s", metadata.SrcIP.String(), metadata.String(), rule.RuleType().String(), rawPc.Chains().String())
 		} else {
 			log.Infoln("%s --> %v doesn't match any rule using DIRECT", metadata.SrcIP.String(), metadata.String())
 		}
@@ -183,12 +183,12 @@ func (t *Tunnel) handleUDPConn(localConn C.ServerAdapter, metadata *C.Metadata, 
 }
 
 func (t *Tunnel) handleTCPConn(localConn C.ServerAdapter, metadata *C.Metadata, proxy C.Proxy, rule C.Rule) {
-	remoConn, err := proxy.Dial(metadata)
+	remoteConn, err := proxy.Dial(metadata)
 	if err != nil {
 		log.Warnln("dial %s error: %s", proxy.Name(), err.Error())
 		return
 	}
-	defer remoConn.Close()
+	defer remoteConn.Close()
 
 	if rule != nil {
 		log.Infoln("%s --> %v match %s using %s", metadata.SrcIP.String(), metadata.String(), rule.RuleType().String(), remoConn.Chains().String())
@@ -198,9 +198,9 @@ func (t *Tunnel) handleTCPConn(localConn C.ServerAdapter, metadata *C.Metadata, 
 
 	switch adapter := localConn.(type) {
 	case *InboundAdapter.HTTPAdapter:
-		t.handleHTTP(adapter, remoConn)
+		t.handleHTTP(adapter, remoteConn)
 	case *InboundAdapter.SocketAdapter:
-		t.handleSocket(adapter, remoConn)
+		t.handleSocket(adapter, remoteConn)
 	}
 }
 

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -191,7 +191,7 @@ func (t *Tunnel) handleTCPConn(localConn C.ServerAdapter, metadata *C.Metadata, 
 	defer remoteConn.Close()
 
 	if rule != nil {
-		log.Infoln("%s --> %v match %s using %s", metadata.SrcIP.String(), metadata.String(), rule.RuleType().String(), remoConn.Chains().String())
+		log.Infoln("%s --> %v match %s using %s", metadata.SrcIP.String(), metadata.String(), rule.RuleType().String(), remoteConn.Chains().String())
 	} else {
 		log.Infoln("%s --> %v doesn't match any rule using DIRECT", metadata.SrcIP.String(), metadata.String())
 	}


### PR DESCRIPTION
1. 根据Go命名规则修改了几处`tunnel.go`里的变量
2. UDP连接关闭的同时也关闭TCP连接，防止因为socks服务端不主动断开TCP连接而造成客户端TCP suspend
3.  在.gitignore里增加了两个path，以后改代码就不用每次手动选择忽略了。😂
