### PR TITLE
Feature: add `prefer` option to url-test

### DIFF
--- a/adapters/outbound/urltest.go
+++ b/adapters/outbound/urltest.go
@@ -113,6 +113,9 @@ func (u *URLTest) fallback() {
 			// calculate variance
 			sum := 0.0
 			n := len(proxy.DelayHistory())
+			if n == 0 {
+				continue
+			}
 			for _, e := range proxy.DelayHistory() {
 				sum += float64(e.Delay)
 			}

--- a/adapters/outbound/urltest.go
+++ b/adapters/outbound/urltest.go
@@ -99,6 +99,9 @@ Loop:
 func (u *URLTest) fallback() {
 	Inf := 0xffff
 	fast := u.fast
+	if fast == nil {
+		fast = u.proxies[0]
+	}
 	prefer := u.prefer
 
 	switch len(fast.DelayHistory()) {

--- a/adapters/outbound/urltest.go
+++ b/adapters/outbound/urltest.go
@@ -99,9 +99,6 @@ Loop:
 func (u *URLTest) fallback() {
 	Inf := 0xffff
 	fast := u.fast
-	if fast == nil {
-		fast = u.proxies[0]
-	}
 	prefer := u.prefer
 
 	switch len(fast.DelayHistory()) {


### PR DESCRIPTION
two options
* fast
* stable


In `fast` mode, fastest server may disconnect cause embarrassment (https://github.com/Dreamacro/clash/issues/273)

`stable` mode may avoid this case

