### PR TITLE
optimize

### DIFF
--- a/adapters/outbound/urltest.go
+++ b/adapters/outbound/urltest.go
@@ -125,8 +125,6 @@ func (u *URLTest) speedTest() {
 	if fast != nil {
 		u.fast = fast.(C.Proxy)
 	}
-
-	<-ctx.Done()
 }
 
 func NewURLTest(option URLTestOption, proxies []C.Proxy) (*URLTest, error) {


### PR DESCRIPTION
If all proxies complete speed test within `defaultURLTestTimeout` seconds, `<-ctx.Done()` will lead to block, goroutine can be released until `defaultURLTestTimeout` seconds later.