### PR TITLE
Keep the origional order of ProxyGroups in config file

### DIFF
--- a/config/utils.go
+++ b/config/utils.go
@@ -55,9 +55,6 @@ func proxyGroupsDagSort(groupsConfig []map[string]interface{}) error {
 
 	// Step 1.1 build dependency graph
 	for idx, mapping := range groupsConfig {
-		// record original order in config file.
-		// this field can be used determinate the display order in FrontEnd.
-		mapping["configIdx"] = idx
 		groupName, existName := mapping["name"].(string)
 		if !existName {
 			return fmt.Errorf("ProxyGroup %d: missing name", idx)


### PR DESCRIPTION
@yichengchen use the `all` array in `GLOBAL` ProxyGroup to sort the `ProxyGroup`s.

This is a brilliant idea and doesn't need something like `Idx` field at all.


