### PR TITLE
Fix: correct TCP dual stack dial

### DIFF
--- a/adapters/outbound/util.go
+++ b/adapters/outbound/util.go
@@ -140,12 +140,9 @@ func dialTimeout(network, address string, timeout time.Duration) (net.Conn, erro
 		} else {
 			c, err = dialer.DialContext(ctx, "tcp4", net.JoinHostPort(ip.String(), port))
 		}
-		if err != nil {
-			return
-		}
 
 		select {
-		case results <- dialResult{Conn: c, error: err, ipv6: ipv6}:
+		case results <- dialResult{Conn: c, error: err, ipv6: ipv6, done: true}:
 		case <-returned:
 			if c != nil {
 				c.Close()


### PR DESCRIPTION
In `dialTimeout` function, the last `select` clause(Line 161) wait for **one  the successful dial**, or **failure of both ipv4 and ipv6**
https://github.com/Dreamacro/clash/blob/09917a2a9519d1acd42b2e1b4031d169eb50203e/adapters/outbound/util.go#L159-L176

But startRacer function didn't return the failure of `Dial`
https://github.com/Dreamacro/clash/blob/09917a2a9519d1acd42b2e1b4031d169eb50203e/adapters/outbound/util.go#L143-L145

So, the `dialTimeout` may keep waiting in (Line 161) if both ipv4 and ipv6 are failed to Dial.