### PR TITLE
enable rest api tls

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ log-level: info
 # A RESTful API for clash
 external-controller: 127.0.0.1:9090
 
+# RESTFUL API TLS options, only enable TLS when both exist
+tls-cert-file:
+tls-private-key-file:
+
 # you can put the static web resource (such as clash-dashboard) to a directory, and clash would serve in `${API}/ui`
 # input is a relative path to the configuration directory or an absolute path
 # external-ui: folder

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,8 @@ type General struct {
 	Mode               T.Mode       `json:"mode"`
 	LogLevel           log.LogLevel `json:"log-level"`
 	ExternalController string       `json:"-"`
+	TLSCertFile        string       `json:"-"`
+	TLSPrivateKeyFile  string       `json:"-"`
 	ExternalUI         string       `json:"-"`
 	Secret             string       `json:"-"`
 }
@@ -98,6 +100,8 @@ type rawConfig struct {
 	Mode               T.Mode       `yaml:"mode"`
 	LogLevel           log.LogLevel `yaml:"log-level"`
 	ExternalController string       `yaml:"external-controller"`
+	TLSCertFile        string       `yaml:"tls-cert-file"`
+	TLSPrivateKeyFile  string       `yaml:"tls-private-key-file"`
 	ExternalUI         string       `yaml:"external-ui"`
 	Secret             string       `yaml:"secret"`
 
@@ -220,6 +224,8 @@ func parseGeneral(cfg *rawConfig) (*General, error) {
 	allowLan := cfg.AllowLan
 	bindAddress := cfg.BindAddress
 	externalController := cfg.ExternalController
+	tlsCertFile := cfg.TLSCertFile
+	tlsPrivateKeyFile := cfg.TLSPrivateKeyFile
 	externalUI := cfg.ExternalUI
 	secret := cfg.Secret
 	mode := cfg.Mode
@@ -244,6 +250,8 @@ func parseGeneral(cfg *rawConfig) (*General, error) {
 		Mode:               mode,
 		LogLevel:           logLevel,
 		ExternalController: externalController,
+		TLSCertFile:        tlsCertFile,
+		TLSPrivateKeyFile:  tlsPrivateKeyFile,
 		ExternalUI:         externalUI,
 		Secret:             secret,
 	}

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -17,7 +17,7 @@ func Parse() error {
 	}
 
 	if cfg.General.ExternalController != "" {
-		go route.Start(cfg.General.ExternalController, cfg.General.Secret)
+		go route.Start(cfg.General)
 	}
 
 	executor.ApplyConfig(cfg, true)

--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Dreamacro/clash/config"
 	C "github.com/Dreamacro/clash/constant"
 	"github.com/Dreamacro/clash/log"
 	T "github.com/Dreamacro/clash/tunnel"
@@ -35,7 +36,12 @@ func SetUIPath(path string) {
 	uiPath = path
 }
 
-func Start(addr string, secret string) {
+func Start(general *config.General) {
+	addr := general.ExternalController
+	secret := general.Secret
+	tlsCertFile := general.TLSCertFile
+	tlsPrivateKeyFile := general.TLSPrivateKeyFile
+
 	if serverAddr != "" {
 		return
 	}
@@ -75,9 +81,16 @@ func Start(addr string, secret string) {
 	}
 
 	log.Infoln("RESTful API listening at: %s", addr)
-	err := http.ListenAndServe(addr, r)
-	if err != nil {
-		log.Errorln("External controller error: %s", err.Error())
+	if tlsCertFile != "" && tlsPrivateKeyFile != "" {
+		err := http.ListenAndServeTLS(addr, tlsCertFile, tlsPrivateKeyFile, r)
+		if err != nil {
+			log.Errorln("External controller error: %s", err.Error())
+		}
+	} else {
+		err := http.ListenAndServe(addr, r)
+		if err != nil {
+			log.Errorln("External controller error: %s", err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
This PR introduces two parameters:

* tls-cert-file the external controller TLS certificate file path
* tls-private-key-file the external controller TLS private key file path

Setting these two parameters will make external controller host under TLS connection.

If the file path does not exist, clash will throw error message and does not start external controller.

```
ERRO[0000] External controller error: open domain.crt: no such file or directory
```