### PR TITLE
fix deadlock

### DIFF
--- a/adapters/outbound/util.go
+++ b/adapters/outbound/util.go
@@ -131,6 +131,7 @@ func dialTimeout(network, address string, timeout time.Duration) (net.Conn, erro
 			ip, err = dns.ResolveIPv4(host)
 		}
 		if err != nil {
+			results <- dialResult{Conn: nil, error: err, ipv6: ipv6, done: true}
 			return
 		}
 


### PR DESCRIPTION
When error is `no such host` will lead to deadlock.
https://github.com/Dreamacro/clash/blob/8adcc4d83b487c6ba143a5f162d26b113a8ae26f/adapters/outbound/util.go#L128-L135
https://github.com/Dreamacro/clash/blob/8adcc4d83b487c6ba143a5f162d26b113a8ae26f/adapters/outbound/util.go#L156-L173