### PR TITLE
Skip dual-stack dial when ip address is provided directly

### DIFF
--- a/adapters/outbound/util.go
+++ b/adapters/outbound/util.go
@@ -110,7 +110,7 @@ func dialTimeout(network, address string, timeout time.Duration) (net.Conn, erro
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// if `host` is an ipv4/ipv6 address rather than hostname, we should not start dual stack race
+	// if `host` is an ipv4/ipv6 address rather than a DNS name, we should not start the dual-stack race
 	if net.ParseIP(host) != nil {
 		if strings.Contains(host, ".") {
 			return dialer.DialContext(ctx, "tcp4", address)

--- a/adapters/outbound/util.go
+++ b/adapters/outbound/util.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -110,15 +109,6 @@ func dialTimeout(network, address string, timeout time.Duration) (net.Conn, erro
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// if `host` is an ipv4/ipv6 address rather than a DNS name, we should not start the dual-stack race
-	if net.ParseIP(host) != nil {
-		if strings.Contains(host, ".") {
-			return dialer.DialContext(ctx, "tcp4", address)
-		} else {
-			return dialer.DialContext(ctx, "tcp6", address)
-		}
-	}
-
 	returned := make(chan struct{})
 	defer close(returned)
 
@@ -170,7 +160,7 @@ func dialTimeout(network, address string, timeout time.Duration) (net.Conn, erro
 				return res.Conn, nil
 			}
 
-			if res.ipv6 {
+			if !res.ipv6 {
 				primary = res
 			} else {
 				fallback = res

--- a/adapters/outbound/util.go
+++ b/adapters/outbound/util.go
@@ -115,8 +115,9 @@ func dialTimeout(network, address string, timeout time.Duration) (net.Conn, erro
 	type dialResult struct {
 		net.Conn
 		error
-		ipv6 bool
-		done bool
+		resolved bool
+		ipv6     bool
+		done     bool
 	}
 	results := make(chan dialResult)
 	var primary, fallback dialResult
@@ -142,6 +143,7 @@ func dialTimeout(network, address string, timeout time.Duration) (net.Conn, erro
 		if result.error != nil {
 			return
 		}
+		result.resolved = true
 
 		if ipv6 {
 			result.Conn, result.error = dialer.DialContext(ctx, "tcp6", net.JoinHostPort(ip.String(), port))
@@ -167,7 +169,13 @@ func dialTimeout(network, address string, timeout time.Duration) (net.Conn, erro
 			}
 
 			if primary.done && fallback.done {
-				return nil, primary.error
+				if primary.resolved {
+					return nil, primary.error
+				} else if fallback.resolved {
+					return nil, fallback.error
+				} else {
+					return nil, primary.error
+				}
 			}
 		}
 	}

--- a/dns/iputil.go
+++ b/dns/iputil.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	errIPNotFound = errors.New("cannot found ip")
+	errIPVersion  = errors.New("ip version error")
 )
 
 // ResolveIPv4 with a host, return ipv4
@@ -18,8 +19,11 @@ func ResolveIPv4(host string) (net.IP, error) {
 	}
 
 	ip := net.ParseIP(host)
-	if ip4 := ip.To4(); ip4 != nil {
-		return ip4, nil
+	if ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4, nil
+		}
+		return nil, errIPVersion
 	}
 
 	if DefaultResolver != nil {
@@ -49,8 +53,11 @@ func ResolveIPv6(host string) (net.IP, error) {
 	}
 
 	ip := net.ParseIP(host)
-	if ip6 := ip.To16(); ip6 != nil {
-		return ip6, nil
+	if ip != nil {
+		if ip6 := ip.To16(); ip6 != nil {
+			return ip6, nil
+		}
+		return nil, errIPVersion
 	}
 
 	if DefaultResolver != nil {

--- a/dns/iputil.go
+++ b/dns/iputil.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"errors"
 	"net"
+	"strings"
 )
 
 var (
@@ -20,8 +21,8 @@ func ResolveIPv4(host string) (net.IP, error) {
 
 	ip := net.ParseIP(host)
 	if ip != nil {
-		if ip4 := ip.To4(); ip4 != nil {
-			return ip4, nil
+		if !strings.Contains(host, ":") {
+			return ip, nil
 		}
 		return nil, errIPVersion
 	}
@@ -36,8 +37,8 @@ func ResolveIPv4(host string) (net.IP, error) {
 	}
 
 	for _, ip := range ipAddrs {
-		if ip4 := ip.To4(); ip4 != nil {
-			return ip4, nil
+		if len(ip) == net.IPv4len {
+			return ip, nil
 		}
 	}
 
@@ -54,8 +55,8 @@ func ResolveIPv6(host string) (net.IP, error) {
 
 	ip := net.ParseIP(host)
 	if ip != nil {
-		if ip6 := ip.To16(); ip6 != nil {
-			return ip6, nil
+		if strings.Contains(host, ":") {
+			return ip, nil
 		}
 		return nil, errIPVersion
 	}
@@ -70,8 +71,8 @@ func ResolveIPv6(host string) (net.IP, error) {
 	}
 
 	for _, ip := range ipAddrs {
-		if ip6 := ip.To16(); ip6 != nil {
-			return ip6, nil
+		if len(ip) == net.IPv6len {
+			return ip, nil
 		}
 	}
 

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -221,13 +221,11 @@ func (r *Resolver) fallbackExchange(m *D.Msg) (msg *D.Msg, err error) {
 
 func (r *Resolver) resolveIP(host string, dnsType uint16) (ip net.IP, err error) {
 	ip = net.ParseIP(host)
-	if dnsType == D.TypeAAAA {
-		if ip6 := ip.To16(); ip6 != nil {
-			return ip6, nil
-		}
-	} else {
-		if ip4 := ip.To4(); ip4 != nil {
-			return ip4, nil
+	if ip != nil {
+		if dnsType == D.TypeAAAA && len(ip) == net.IPv6len {
+			return ip, nil
+		} else if dnsType == D.TypeA && len(ip) == net.IPv4len {
+			return ip, nil
 		}
 	}
 


### PR DESCRIPTION
When an IP address is provided, we should not start the dual-stack dial procedure.

---

Sometimes, when users are connecting remote host with **IP address** through clash

```
 curl --socks5-hostname 127.0.0.1:7891 http://224.0.0.0
```
For now, Clash will output one line warning

> WARN[0000] dial DIRECT error: dial tcp6: address 224.0.0.0: no suitable address found 

Because if both `IPv4` and `IPv6` are failed to connect, `dialTimeout` will return the `IPv6` error
https://github.com/Dreamacro/clash/blob/1a8a6d0b5d28161069c23560464be9f1e0eb6fd7/adapters/outbound/util.go#L163-L167

Actually, when users are using IPv4 address, clash should not try to connect with IPv6.