### PR TITLE
Fix: correctly initialize cancel of picker when using WithTimeout

### DIFF
--- a/common/picker/picker.go
+++ b/common/picker/picker.go
@@ -29,7 +29,7 @@ func WithContext(ctx context.Context) (*Picker, context.Context) {
 // but it doesn't cancel when first element return.
 func WithTimeout(ctx context.Context, timeout time.Duration) (*Picker, context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
-	return &Picker{}, ctx, cancel
+	return &Picker{cancel: cancel}, ctx, cancel
 }
 
 // Wait blocks until all function calls from the Go method have returned,

--- a/common/picker/picker_test.go
+++ b/common/picker/picker_test.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -38,5 +39,33 @@ func TestPicker_Timeout(t *testing.T) {
 	number := picker.Wait()
 	if number != nil {
 		t.Error("should recv nil")
+	}
+}
+
+func TestPicker_Timeout_ShortCircuit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	picker, ctx, _ := WithTimeout(ctx, time.Second)
+
+	var number int32 = 0
+
+	inc := func() (interface{}, error) {
+		select {
+		case <-ctx.Done():
+			return int32(0), nil
+		default:
+			return atomic.AddInt32(&number, 1), nil
+		}
+	}
+
+	picker.Go(sleepAndSend(ctx, 0, 0))
+	wastedCount := 10
+	for i := 0; i < wastedCount; i++ {
+		picker.Go(inc)
+	}
+
+	picker.Wait()
+	if number == int32(wastedCount) {
+		t.Error("first finished task does not short-circuit others correctly")
 	}
 }


### PR DESCRIPTION
correctly initialize cancel of picker when using WithTimeout, so that
first finished task will short-circuit others correctly.