### PR TITLE
[Feature] Add Redirect Adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ vendor
 
 # macOS file
 .DS_Store
+
+# Visual Studio Code
+.vscode

--- a/adapters/outbound/redirect.go
+++ b/adapters/outbound/redirect.go
@@ -1,0 +1,90 @@
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+
+	C "github.com/Dreamacro/clash/constant"
+)
+
+type Redirect struct {
+	*Base
+	ToHost    string
+	ToAddress net.IP
+	ToPort    string
+	forward   C.Proxy
+}
+
+type RedirectOption struct {
+	Name      string   `proxy:"name"`
+	ToHost    string   `proxy:"to-host,omitempty"`
+	ToAddress string   `proxy:"to-address,omitempty"`
+	ToPort    string   `proxy:"to-port,omitempty"`
+	Proxies   []string `proxy:"proxies"`
+}
+
+func (s *Redirect) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
+	s.redirectMetadata(metadata)
+
+	c, err := s.forward.DialContext(ctx, metadata)
+	if err == nil {
+		c.AppendToChains(s)
+	}
+	return c, err
+}
+
+func (s *Redirect) DialUDP(metadata *C.Metadata) (C.PacketConn, net.Addr, error) {
+	s.redirectMetadata(metadata)
+
+	pc, addr, err := s.forward.DialUDP(metadata)
+	if err == nil {
+		pc.AppendToChains(s)
+	}
+	return pc, addr, err
+}
+
+func (s *Redirect) SupportUDP() bool {
+	return s.forward.SupportUDP()
+}
+
+func (s *Redirect) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"type":    s.Type().String(),
+		"forward": s.forward,
+	})
+}
+
+func (s *Redirect) redirectMetadata(metadata *C.Metadata) {
+	if len(s.ToHost) != 0 {
+		metadata.DstIP = nil
+		metadata.Host = s.ToHost
+	}
+
+	if len(s.ToAddress) != 0 {
+		metadata.DstIP = s.ToAddress
+	}
+
+	if len(s.ToPort) != 0 {
+		metadata.DstPort = s.ToPort
+	}
+}
+
+func NewRedirect(name string, option RedirectOption, proxies []C.Proxy) (*Redirect, error) {
+	if len(proxies) != 1 {
+		return nil, errors.New("Provide only one proxy")
+	}
+
+	s := &Redirect{
+		Base: &Base{
+			name: name,
+			tp:   C.Redirect,
+		},
+		forward:   proxies[0],
+		ToHost:    option.ToHost,
+		ToAddress: net.ParseIP(option.ToAddress),
+		ToPort:    option.ToPort,
+	}
+	return s, nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -376,6 +376,19 @@ func parseProxies(cfg *rawConfig) (map[string]C.Proxy, error) {
 				return nil, fmt.Errorf("ProxyGroup %s: %s", groupName, err.Error())
 			}
 			group, err = adapters.NewSelector(selectorOption.Name, ps)
+		case "redirect":
+			redirectOption := &adapters.RedirectOption{}
+			err = decoder.Decode(mapping, redirectOption)
+			if err != nil {
+				break
+			}
+
+			ps, err = getProxies(proxies, redirectOption.Proxies)
+			if err != nil {
+				return nil, fmt.Errorf("ProxyGroup %s: %s", groupName, err.Error())
+			}
+
+			group, err = adapters.NewRedirect(redirectOption.Name, *redirectOption, ps)
 		case "fallback":
 			fallbackOption := &adapters.FallbackOption{}
 			err = decoder.Decode(mapping, fallbackOption)

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -13,6 +13,7 @@ const (
 	Fallback
 	Reject
 	Selector
+	Redirect
 	Shadowsocks
 	Snell
 	Socks5
@@ -92,6 +93,8 @@ func (at AdapterType) String() string {
 		return "Reject"
 	case Selector:
 		return "Selector"
+	case Redirect:
+		return "Redirect"
 	case Shadowsocks:
 		return "Shadowsocks"
 	case Snell:


### PR DESCRIPTION
添加用于网络本地调试的 重定向适配器

**样例配置**
```yaml
Proxy Group:
  - name: "REDIRECT"
    type: "redirect"
    to-host: 9.9.9.9            // 可选, 修改目标主机
    to-address: 127.0.0.1  // 可选, 修改目标地址
    to-port: 8080               // 可选, 修改目标端口
    proxies: [DIRECT]       // 上游, 只能为一个

Rule:
  - IP-CIDR,9.9.9.9/24,REDIRECT
  - MATCH,DIRECT
```

* **行为**
   在建立连接前修改连接的 **目标主机**/**目标地址**/**目标端口**
* **可能的用途**
   - 本地调试 Web 时 将 目的地址 指向 127.0.0.1 即可使用远程域名在本地调试, 同时可使用高位端口
   - DNS 重定向