### PR TITLE
UDP relay refactor

### DIFF
--- a/adapters/inbound/packet.go
+++ b/adapters/inbound/packet.go
@@ -21,7 +21,7 @@ func NewPacket(target socks5.Addr, packet C.UDPPacket, source C.Type, netType C.
 	metadata := parseSocksAddr(target)
 	metadata.NetWork = netType
 	metadata.Type = source
-	if ip, port, err := parseAddr(packet.SourceAddr().String()); err == nil {
+	if ip, port, err := parseAddr(packet.LocalAddr().String()); err == nil {
 		metadata.SrcIP = ip
 		metadata.SrcPort = port
 	}

--- a/adapters/inbound/packet.go
+++ b/adapters/inbound/packet.go
@@ -1,0 +1,33 @@
+package inbound
+
+import (
+	"github.com/Dreamacro/clash/component/socks5"
+	C "github.com/Dreamacro/clash/constant"
+)
+
+// PacketAdapter is a UDP Packet adapter for socks/redir/tun
+type PacketAdapter struct {
+	C.UDPPacket
+	metadata *C.Metadata
+}
+
+// Metadata return destination metadata
+func (s *PacketAdapter) Metadata() *C.Metadata {
+	return s.metadata
+}
+
+// NewPacket is PacketAdapter generator
+func NewPacket(target socks5.Addr, packet C.UDPPacket, source C.Type, netType C.NetWork) *PacketAdapter {
+	metadata := parseSocksAddr(target)
+	metadata.NetWork = netType
+	metadata.Type = source
+	if ip, port, err := parseAddr(packet.SourceAddr().String()); err == nil {
+		metadata.SrcIP = ip
+		metadata.SrcPort = port
+	}
+
+	return &PacketAdapter{
+		UDPPacket: packet,
+		metadata:  metadata,
+	}
+}

--- a/adapters/inbound/packet.go
+++ b/adapters/inbound/packet.go
@@ -11,7 +11,7 @@ type PacketAdapter struct {
 	metadata *C.Metadata
 }
 
-// Metadata return destination metadata
+// Metadata returns destination metadata
 func (s *PacketAdapter) Metadata() *C.Metadata {
 	return s.metadata
 }

--- a/adapters/outbound/shadowsocks.go
+++ b/adapters/outbound/shadowsocks.go
@@ -206,7 +206,7 @@ func (uc *ssUDPConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	var from net.Addr
 	if e == nil {
 		// Get the source IP/Port of packet.
-		from = addr.ToUDPAddr()
+		from = addr.UDPAddr()
 	}
 	copy(b, b[len(addr):])
 	return n - len(addr), from, e

--- a/adapters/outbound/shadowsocks.go
+++ b/adapters/outbound/shadowsocks.go
@@ -201,8 +201,13 @@ func (uc *ssUDPConn) WriteTo(b []byte, addr net.Addr) (n int, err error) {
 }
 
 func (uc *ssUDPConn) ReadFrom(b []byte) (int, net.Addr, error) {
-	n, a, e := uc.PacketConn.ReadFrom(b)
+	n, _, e := uc.PacketConn.ReadFrom(b)
 	addr := socks5.SplitAddr(b[:n])
+	var from net.Addr
+	if e == nil {
+		// Get the source IP/Port of packet.
+		from = addr.ToUDPAddr()
+	}
 	copy(b, b[len(addr):])
-	return n - len(addr), a, e
+	return n - len(addr), from, e
 }

--- a/component/fakeip/pool.go
+++ b/component/fakeip/pool.go
@@ -62,12 +62,12 @@ func (p *Pool) LookBack(ip net.IP) (string, bool) {
 	return "", false
 }
 
-// LookupHost return if host in host
-func (p *Pool) LookupHost(host string) bool {
+// LookupHost return if domain in host
+func (p *Pool) LookupHost(domain string) bool {
 	if p.host == nil {
 		return false
 	}
-	return p.host.Search(host) != nil
+	return p.host.Search(domain) != nil
 }
 
 // Exist returns if given ip exists in fake-ip pool

--- a/component/fakeip/pool.go
+++ b/component/fakeip/pool.go
@@ -60,7 +60,7 @@ func (p *Pool) LookBack(ip net.IP) (string, bool) {
 	return "", false
 }
 
-// Exist return if given ip exists in fake-ip pool
+// Exist returns if given ip exists in fake-ip pool
 func (p *Pool) Exist(ip net.IP) bool {
 	p.mux.Lock()
 	defer p.mux.Unlock()

--- a/component/fakeip/pool.go
+++ b/component/fakeip/pool.go
@@ -60,6 +60,20 @@ func (p *Pool) LookBack(ip net.IP) (string, bool) {
 	return "", false
 }
 
+// Exist return if given ip exists in fake-ip pool
+func (p *Pool) Exist(ip net.IP) bool {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	if ip = ip.To4(); ip == nil {
+		return false
+	}
+
+	n := ipToUint(ip.To4())
+	offset := n - p.min + 1
+	return p.cache.Exist(offset)
+}
+
 // Gateway return gateway ip
 func (p *Pool) Gateway() net.IP {
 	return uintToIP(p.gateway)

--- a/component/socks5/socks5.go
+++ b/component/socks5/socks5.go
@@ -2,6 +2,7 @@ package socks5
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
 	"net"
@@ -60,6 +61,25 @@ func (a Addr) String() string {
 	}
 
 	return net.JoinHostPort(host, port)
+}
+
+// ToUDPAddr convert a socks5.Addr to *net.UDPAddr
+func (a Addr) ToUDPAddr() *net.UDPAddr {
+	if len(a) == 0 {
+		return nil
+	}
+	switch a[0] {
+	case AtypIPv4:
+		var ip [net.IPv4len]byte
+		copy(ip[0:], a[1:1+net.IPv4len])
+		return &net.UDPAddr{IP: net.IP(ip[:]), Port: int(binary.BigEndian.Uint16(a[1+net.IPv4len : 1+net.IPv4len+2]))}
+	case AtypIPv6:
+		var ip [net.IPv6len]byte
+		copy(ip[0:], a[1:1+net.IPv6len])
+		return &net.UDPAddr{IP: net.IP(ip[:]), Port: int(binary.BigEndian.Uint16(a[1+net.IPv6len : 1+net.IPv6len+2]))}
+	}
+	// Other Atyp
+	return nil
 }
 
 // SOCKS errors as defined in RFC 1928 section 6.
@@ -336,6 +356,39 @@ func ParseAddr(s string) Addr {
 	addr[len(addr)-2], addr[len(addr)-1] = byte(portnum>>8), byte(portnum)
 
 	return addr
+}
+
+// ParseAddrFromNetAddr parse a socks addr from net.addr
+// This is a fast path of ParseAddr(addr.String())
+func ParseAddrFromNetAddr(addr net.Addr) Addr {
+	var hostip net.IP
+	var port int
+	if udpaddr, ok := addr.(*net.UDPAddr); ok {
+		hostip = udpaddr.IP
+		port = udpaddr.Port
+	} else if tcpaddr, ok := addr.(*net.TCPAddr); ok {
+		hostip = tcpaddr.IP
+		port = tcpaddr.Port
+	}
+	if hostip != nil {
+		var parsed Addr
+		if ip4 := hostip.To4(); ip4.DefaultMask() != nil {
+			parsed = make([]byte, 1+net.IPv4len+2)
+			parsed[0] = AtypIPv4
+			copy(parsed[1:], ip4)
+			binary.BigEndian.PutUint16(parsed[1+net.IPv4len:], uint16(port))
+
+		} else {
+			parsed = make([]byte, 1+net.IPv6len+2)
+			parsed[0] = AtypIPv6
+			copy(parsed[1:], hostip)
+			binary.BigEndian.PutUint16(parsed[1+net.IPv6len:], uint16(port))
+		}
+		return parsed
+	}
+
+	// Finally, fallback to ParseAddr
+	return ParseAddr(addr.String())
 }
 
 // DecodeUDPPacket split `packet` to addr payload, and this function is mutable with `packet`

--- a/component/socks5/socks5.go
+++ b/component/socks5/socks5.go
@@ -63,7 +63,7 @@ func (a Addr) String() string {
 	return net.JoinHostPort(host, port)
 }
 
-// ToUDPAddr convert a socks5.Addr to *net.UDPAddr
+// ToUDPAddr converts a socks5.Addr to *net.UDPAddr
 func (a Addr) ToUDPAddr() *net.UDPAddr {
 	if len(a) == 0 {
 		return nil

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -118,7 +118,7 @@ type UDPPacket interface {
 	// WriteFrom writes the payload with source IP/Port equals addr
 	// - variable source IP/Port is important to STUN
 	// - if addr is not provided, WriteFrom will wirte out UDP packet with SourceIP/Prot equals to origional Target,
-	//	 this is important when using Fake-IP.
+	//   this is important when using Fake-IP.
 	WriteFrom(b []byte, addr net.Addr) (n int, err error)
 
 	// Close closes the underlaying connection.

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -123,6 +123,6 @@ type UDPPacket interface {
 	// Close closes the underlaying connection.
 	Close() error
 
-	// SourceAddr returns the source IP/Port of packet
-	SourceAddr() net.Addr
+	// LocalAddr returns the source IP/Port of packet
+	LocalAddr() net.Addr
 }

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -116,8 +116,9 @@ type UDPPacket interface {
 	Data() []byte
 
 	// WriteFrom writes the payload with source IP/Port equals addr
-	// variable source IP/Port is import to STUN
-	// if addr is not provided, WriteFrom will wirte out UDP packet with SourceIP/Prot equals
+	// - variable source IP/Port is important to STUN
+	// - if addr is not provided, WriteFrom will wirte out UDP packet with SourceIP/Prot equals to origional Target,
+	//	 this is important when using Fake-IP.
 	WriteFrom(b []byte, addr net.Addr) (n int, err error)
 
 	// Close closes the underlaying connection.

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -109,3 +109,20 @@ func (at AdapterType) String() string {
 		return "Unknown"
 	}
 }
+
+// UDPPacket contains the data of UDP packet, and offers control/info of UDP packet's source
+type UDPPacket interface {
+	// Data get the payload of UDP Packet
+	Data() []byte
+
+	// WriteFrom writes the payload with source IP/Port equals addr
+	// variable source IP/Port is import to STUN
+	// if addr is not provided, WriteFrom will wirte out UDP packet with SourceIP/Prot equals
+	WriteFrom(b []byte, addr net.Addr) (n int, err error)
+
+	// Close closes the underlaying connection.
+	Close() error
+
+	// SourceAddr returns the source IP/Port of packet
+	SourceAddr() net.Addr
+}

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -115,11 +115,11 @@ type UDPPacket interface {
 	// Data get the payload of UDP Packet
 	Data() []byte
 
-	// WriteFrom writes the payload with source IP/Port equals addr
+	// WriteBack writes the payload with source IP/Port equals addr
 	// - variable source IP/Port is important to STUN
-	// - if addr is not provided, WriteFrom will wirte out UDP packet with SourceIP/Prot equals to origional Target,
+	// - if addr is not provided, WriteBack will wirte out UDP packet with SourceIP/Prot equals to origional Target,
 	//   this is important when using Fake-IP.
-	WriteFrom(b []byte, addr net.Addr) (n int, err error)
+	WriteBack(b []byte, addr net.Addr) (n int, err error)
 
 	// Close closes the underlaying connection.
 	Close() error

--- a/dns/middleware.go
+++ b/dns/middleware.go
@@ -71,7 +71,7 @@ func compose(middlewares []middleware, endpoint handler) handler {
 func newHandler(resolver *Resolver) handler {
 	middlewares := []middleware{}
 
-	if resolver.IsFakeIP() {
+	if resolver.FakeIPEnabled() {
 		middlewares = append(middlewares, withFakeIP(resolver.pool))
 	}
 

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -166,8 +166,17 @@ func (r *Resolver) IsMapping() bool {
 	return r.mapping
 }
 
-func (r *Resolver) IsFakeIP() bool {
+// FakeIPEnabled returns if fake-ip is enabled
+func (r *Resolver) FakeIPEnabled() bool {
 	return r.fakeip
+}
+
+// IsFakeIP determine if given ip is a fake-ip
+func (r *Resolver) IsFakeIP(ip net.IP) bool {
+	if r.FakeIPEnabled() {
+		return r.pool.Exist(ip)
+	}
+	return false
 }
 
 func (r *Resolver) batchExchange(clients []resolver, m *D.Msg) (msg *D.Msg, err error) {

--- a/proxy/socks/udp.go
+++ b/proxy/socks/udp.go
@@ -1,7 +1,6 @@
 package socks
 
 import (
-	"bytes"
 	"net"
 
 	adapters "github.com/Dreamacro/clash/adapters/inbound"
@@ -57,12 +56,12 @@ func handleSocksUDP(pc net.PacketConn, buf []byte, addr net.Addr) {
 		pool.BufPool.Put(buf[:cap(buf)])
 		return
 	}
-	conn := &fakeConn{
+	packet := &fakeConn{
 		PacketConn: pc,
 		remoteAddr: addr,
 		targetAddr: target,
-		buffer:     bytes.NewBuffer(payload),
+		payload:    payload,
 		bufRef:     buf,
 	}
-	tun.Add(adapters.NewSocket(target, conn, C.SOCKS, C.UDP))
+	tun.AddPacket(adapters.NewPacket(target, packet, C.SOCKS, C.UDP))
 }

--- a/proxy/socks/utils.go
+++ b/proxy/socks/utils.go
@@ -35,7 +35,8 @@ func (c *fakeConn) WriteFrom(b []byte, addr net.Addr) (n int, err error) {
 	return c.PacketConn.WriteTo(packet, c.remoteAddr)
 }
 
-func (c *fakeConn) SourceAddr() net.Addr {
+// LocalAddr returns the source IP/Port of UDP Packet
+func (c *fakeConn) LocalAddr() net.Addr {
 	return c.remoteAddr
 }
 

--- a/proxy/socks/utils.go
+++ b/proxy/socks/utils.go
@@ -19,14 +19,12 @@ func (c *fakeConn) Data() []byte {
 	return c.payload
 }
 
-// WriteFrom wirtes UDP packet with source(ip, port) = `addr`
-func (c *fakeConn) WriteFrom(b []byte, addr net.Addr) (n int, err error) {
-	var from socks5.Addr
-	if addr == nil {
-		// if addr is not provided, use the original source
-		from = c.targetAddr
-	} else {
-		from = socks5.ParseAddrFromNetAddr(addr)
+// WriteBack wirtes UDP packet with source(ip, port) = `addr`
+func (c *fakeConn) WriteBack(b []byte, addr net.Addr) (n int, err error) {
+	from := c.targetAddr
+	if addr != nil {
+		// if addr is provided, use the parsed addr
+		from = socks5.ParseAddrToSocksAddr(addr)
 	}
 	packet, err := socks5.EncodeUDPPacket(from, b)
 	if err != nil {

--- a/proxy/socks/utils.go
+++ b/proxy/socks/utils.go
@@ -19,7 +19,7 @@ func (c *fakeConn) Data() []byte {
 	return c.payload
 }
 
-// Wirte UDP packet with source(ip, port) = `addr`
+// WriteFrom wirtes UDP packet with source(ip, port) = `addr`
 func (c *fakeConn) WriteFrom(b []byte, addr net.Addr) (n int, err error) {
 	var from socks5.Addr
 	if addr == nil {

--- a/proxy/socks/utils.go
+++ b/proxy/socks/utils.go
@@ -1,7 +1,6 @@
 package socks
 
 import (
-	"bytes"
 	"net"
 
 	"github.com/Dreamacro/clash/common/pool"
@@ -12,23 +11,31 @@ type fakeConn struct {
 	net.PacketConn
 	remoteAddr net.Addr
 	targetAddr socks5.Addr
-	buffer     *bytes.Buffer
+	payload    []byte
 	bufRef     []byte
 }
 
-func (c *fakeConn) Read(b []byte) (n int, err error) {
-	return c.buffer.Read(b)
+func (c *fakeConn) Data() []byte {
+	return c.payload
 }
 
-func (c *fakeConn) Write(b []byte) (n int, err error) {
-	packet, err := socks5.EncodeUDPPacket(c.targetAddr, b)
+// Wirte UDP packet with source(ip, port) = `addr`
+func (c *fakeConn) WriteFrom(b []byte, addr net.Addr) (n int, err error) {
+	var from socks5.Addr
+	if addr == nil {
+		// if addr is not provided, use the original source
+		from = c.targetAddr
+	} else {
+		from = socks5.ParseAddrFromNetAddr(addr)
+	}
+	packet, err := socks5.EncodeUDPPacket(from, b)
 	if err != nil {
 		return
 	}
 	return c.PacketConn.WriteTo(packet, c.remoteAddr)
 }
 
-func (c *fakeConn) RemoteAddr() net.Addr {
+func (c *fakeConn) SourceAddr() net.Addr {
 	return c.remoteAddr
 }
 

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -104,7 +104,7 @@ func (t *Tunnel) handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key str
 			from = nil
 		}
 
-		n, err = packet.WriteFrom(buf[:n], from)
+		n, err = packet.WriteBack(buf[:n], from)
 		if err != nil {
 			return
 		}

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -88,7 +88,7 @@ func (t *Tunnel) handleUDPToRemote(packet C.UDPPacket, pc net.PacketConn, addr n
 	DefaultManager.Upload() <- int64(len(packet.Data()))
 }
 
-func (t *Tunnel) handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, timeout time.Duration) {
+func (t *Tunnel) handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, omitSrcAddr bool, timeout time.Duration) {
 	buf := pool.BufPool.Get().([]byte)
 	defer pool.BufPool.Put(buf[:cap(buf)])
 	defer t.natTable.Delete(key)
@@ -99,6 +99,9 @@ func (t *Tunnel) handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key str
 		n, from, err := pc.ReadFrom(buf)
 		if err != nil {
 			return
+		}
+		if from != nil && omitSrcAddr {
+			from = nil
 		}
 
 		n, err = packet.WriteFrom(buf[:n], from)

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	adapters "github.com/Dreamacro/clash/adapters/inbound"
+	C "github.com/Dreamacro/clash/constant"
+
 	"github.com/Dreamacro/clash/common/pool"
 )
 
@@ -79,21 +81,14 @@ func (t *Tunnel) handleHTTP(request *adapters.HTTPAdapter, outbound net.Conn) {
 	}
 }
 
-func (t *Tunnel) handleUDPToRemote(conn net.Conn, pc net.PacketConn, addr net.Addr) {
-	buf := pool.BufPool.Get().([]byte)
-	defer pool.BufPool.Put(buf[:cap(buf)])
-
-	n, err := conn.Read(buf)
-	if err != nil {
+func (t *Tunnel) handleUDPToRemote(packet C.UDPPacket, pc net.PacketConn, addr net.Addr) {
+	if _, err := pc.WriteTo(packet.Data(), addr); err != nil {
 		return
 	}
-	if _, err = pc.WriteTo(buf[:n], addr); err != nil {
-		return
-	}
-	DefaultManager.Upload() <- int64(n)
+	DefaultManager.Upload() <- int64(len(packet.Data()))
 }
 
-func (t *Tunnel) handleUDPToLocal(conn net.Conn, pc net.PacketConn, key string, timeout time.Duration) {
+func (t *Tunnel) handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, timeout time.Duration) {
 	buf := pool.BufPool.Get().([]byte)
 	defer pool.BufPool.Put(buf[:cap(buf)])
 	defer t.natTable.Delete(key)
@@ -101,12 +96,12 @@ func (t *Tunnel) handleUDPToLocal(conn net.Conn, pc net.PacketConn, key string, 
 
 	for {
 		pc.SetReadDeadline(time.Now().Add(timeout))
-		n, _, err := pc.ReadFrom(buf)
+		n, from, err := pc.ReadFrom(buf)
 		if err != nil {
 			return
 		}
 
-		n, err = conn.Write(buf[:n])
+		n, err = packet.WriteFrom(buf[:n], from)
 		if err != nil {
 			return
 		}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -99,7 +99,7 @@ func (t *Tunnel) SetMode(mode Mode) {
 	t.mode = mode
 }
 
-// processUDP start a loop to handle udp packet
+// processUDP starts a loop to handle udp packet
 func (t *Tunnel) processUDP() {
 	queue := t.udpQueue.Out()
 	for elm := range queue {


### PR DESCRIPTION
# Goal

1. [x] Full-cone NAT (fix #403)
2. [x] Auto-scaling udp workers(fix #436)

# Detail 

1. More loose NAT

Add a `WriteFrom` interface allowing outbound to write out packets with sourceIP/sourcePort different from origin target.

Tested on **shadowsocks**(outbound) and **socks5**(inbound), with the help of [go-tun2socks](https://github.com/eycorsican/go-tun2socks)  to create tun interface
(*from* bc81c9f)
<details>
  <summary>Logs from go-stun</summary>

```
2019/12/21 20:12:26 Do Test1
2019/12/21 20:12:26 Send To: 216.93.246.18:3478
2019/12/21 20:12:26 Received: {packet nil: false, local: 20.176.71.59:62383, remote: 216.93.246.18:3478, changed: 56.162.98.102:32823, other: <nil>, identical: false}
2019/12/21 20:12:26 Do Test2
2019/12/21 20:12:26 Send To: 216.93.246.18:3478
2019/12/21 20:12:26 Received: {packet nil: false, local: 24.25.155.0:40568, remote: 216.93.246.17:3479, changed: 73.82.169.128:13084, other: <nil>, identical: false}
NAT Type: Full cone NAT
External IP Family: 1
External IP: 20.176.71.59
External Port: 62383
```
</details>

2. Fix memory leak in UDP relay

I think there are too few UDP relay goroutines that can not handle so much UDP traffic. This PR add a feature that can watch the **queue length** and Auto-scaling UDP workers

# Potential problems

I still don't know where this buffer is given back to the pool. But the test(#436) doesn't show potential memory leak thereafter.

https://github.com/Dreamacro/clash/blob/e5284cf647717a8087a185d88d15a01096274bc2/proxy/socks/udp.go#L28-L29