### PR TITLE
Rule match cache

### DIFF
--- a/common/cache/lrucache.go
+++ b/common/cache/lrucache.go
@@ -164,6 +164,14 @@ func (c *LruCache) deleteElement(le *list.Element) {
 	}
 }
 
+// Clear delete all the items
+func (c *LruCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache = make(map[interface{}]*list.Element)
+}
+
 type entry struct {
 	key     interface{}
 	value   interface{}

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -83,3 +83,20 @@ func (m *Metadata) String() string {
 func (m *Metadata) Valid() bool {
 	return m.Host != "" || m.DstIP != nil
 }
+
+func (m *Metadata) DeepCopy() Metadata {
+	result := *m
+	if (m.SrcIP) != nil {
+		result.SrcIP = copyIP(m.SrcIP)
+	}
+	if (m.DstIP) != nil {
+		result.SrcIP = copyIP(m.DstIP)
+	}
+	return result
+}
+
+func copyIP(ip net.IP) net.IP {
+	dup := make(net.IP, len(ip))
+	copy(dup, ip)
+	return dup
+}

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -83,20 +83,3 @@ func (m *Metadata) String() string {
 func (m *Metadata) Valid() bool {
 	return m.Host != "" || m.DstIP != nil
 }
-
-func (m *Metadata) DeepCopy() Metadata {
-	result := *m
-	if (m.SrcIP) != nil {
-		result.SrcIP = copyIP(m.SrcIP)
-	}
-	if (m.DstIP) != nil {
-		result.SrcIP = copyIP(m.DstIP)
-	}
-	return result
-}
-
-func copyIP(ip net.IP) net.IP {
-	dup := make(net.IP, len(ip))
-	copy(dup, ip)
-	return dup
-}

--- a/tunnel/rulecache.go
+++ b/tunnel/rulecache.go
@@ -1,0 +1,106 @@
+package tunnel
+
+import (
+	"github.com/Dreamacro/clash/common/cache"
+	C "github.com/Dreamacro/clash/constant"
+	"github.com/Dreamacro/clash/log"
+)
+
+var (
+	ruleMatchCache *RuleMatchLruCache
+)
+
+// RuleMatchLruCache lru cache for rule match result
+// Source port always change when creating a new connection.
+// If source port is not defined in rule, map key can ommit it, and just set SrcPort null
+// Otherwise map key must contain source port
+type RuleMatchLruCache struct {
+	srcPorts map[string]bool // key is src port
+	cache    *cache.LruCache
+}
+
+// ruleMatchCacheKey match lru cache key, change Metadata field to primitive type, so it can be used as map key
+type ruleMatchCacheKey struct {
+	NetWork  C.NetWork
+	Type     C.Type
+	SrcIP    string
+	DstIP    string
+	SrcPort  string
+	DstPort  string
+	AddrType int
+	Host     string
+}
+
+// ruleMatchCacheValue match lru cache value
+type ruleMatchCacheValue struct {
+	proxy C.Proxy
+	rule  C.Rule
+}
+
+// AddSrcPort add source port defined in the SrcPort type rule
+func (ruleCache *RuleMatchLruCache) AddSrcPort(port string) {
+	ruleCache.srcPorts[port] = true
+}
+
+// withSrcPortKey check if map key must contain source port
+func (ruleCache *RuleMatchLruCache) withSrcPortKey(port string) bool {
+	_, exist := ruleCache.srcPorts[port]
+	return exist
+}
+
+func (ruleCache *RuleMatchLruCache) newRuleMatchCacheKey(metadata C.Metadata) ruleMatchCacheKey {
+	key := ruleMatchCacheKey{
+		NetWork:  metadata.NetWork,
+		Type:     metadata.Type,
+		DstPort:  metadata.DstPort,
+		AddrType: metadata.AddrType,
+		Host:     metadata.Host,
+	}
+	if metadata.SrcIP != nil {
+		key.SrcIP = metadata.SrcIP.String()
+	}
+	if metadata.DstIP != nil {
+		key.DstIP = metadata.DstIP.String()
+	}
+	if len(metadata.SrcPort) > 0 && ruleCache.withSrcPortKey(metadata.SrcPort) {
+		key.SrcPort = metadata.SrcPort
+	}
+
+	return key
+}
+
+// Put put result into cache
+func (ruleCache *RuleMatchLruCache) Put(metadata C.Metadata, proxy C.Proxy, rule C.Rule) {
+	log.Debugln("[RULE] put into cache metadata %s match rule %s hit in cache", metadata, rule)
+	key := ruleCache.newRuleMatchCacheKey(metadata)
+	value := ruleMatchCacheValue{proxy: proxy, rule: rule}
+	ruleCache.cache.Set(key, value)
+}
+
+// Get get proxy from cache
+func (ruleCache *RuleMatchLruCache) Get(metadata C.Metadata) (C.Proxy, C.Rule, bool) {
+	key := ruleCache.newRuleMatchCacheKey(metadata)
+	elem, exist := ruleCache.cache.Get(key)
+	if exist {
+		value := elem.(ruleMatchCacheValue)
+		log.Debugln("[RULE] metadata %s match rule %s hit in cache", value.proxy, value.rule)
+		return value.proxy, value.rule, exist
+	}
+	return nil, nil, exist
+}
+
+// Clear clear all the cache
+func (ruleCache *RuleMatchLruCache) Clear(ruleUpdate bool) {
+	ruleCache.cache.Clear()
+	if ruleUpdate {
+		ruleCache.srcPorts = make(map[string]bool)
+	}
+}
+
+// NewRuleMatchLruCache create new RuleMatchLruCache
+func NewRuleMatchLruCache() *RuleMatchLruCache {
+	return &RuleMatchLruCache{
+		srcPorts: make(map[string]bool),
+		cache:    cache.NewLRUCache(cache.WithSize(1000)),
+	}
+}

--- a/tunnel/rulecache.go
+++ b/tunnel/rulecache.go
@@ -71,7 +71,8 @@ func (ruleCache *RuleMatchLruCache) newRuleMatchCacheKey(metadata C.Metadata) ru
 
 // Put put result into cache
 func (ruleCache *RuleMatchLruCache) Put(metadata C.Metadata, proxy C.Proxy, rule C.Rule) {
-	log.Debugln("[RULE] put into cache metadata %s match rule %s hit in cache", metadata, rule)
+	log.Debugln("[RULE] put into cache metadata host %s, dst ip %s, match rule %s %s, proxy %s",
+		metadata.Host, metadata.DstIP, rule.RuleType(), rule.Payload(), proxy.Name())
 	key := ruleCache.newRuleMatchCacheKey(metadata)
 	value := ruleMatchCacheValue{proxy: proxy, rule: rule}
 	ruleCache.cache.Set(key, value)
@@ -83,7 +84,9 @@ func (ruleCache *RuleMatchLruCache) Get(metadata C.Metadata) (C.Proxy, C.Rule, b
 	elem, exist := ruleCache.cache.Get(key)
 	if exist {
 		value := elem.(ruleMatchCacheValue)
-		log.Debugln("[RULE] metadata %s match rule %s hit in cache", value.proxy, value.rule)
+		log.Debugln("[RULE] metadata host %s, dst ip %s, match rule %s %s, proxy %s hit in cache",
+			metadata.Host, metadata.DstIP, value.rule.RuleType(), value.rule.Payload(),
+			value.proxy.Name())
 		return value.proxy, value.rule, exist
 	}
 	return nil, nil, exist

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -272,12 +272,12 @@ func (t *Tunnel) match(metadata *C.Metadata) (C.Proxy, C.Rule, error) {
 	t.configMux.RLock()
 	defer t.configMux.RUnlock()
 
-	if proxy, rule, exist := t.ruleMatchCache.Get(*metadata); exist {
+	key := t.ruleMatchCache.NewRuleMatchCacheKey(*metadata)
+	if proxy, rule, exist := t.ruleMatchCache.Get(key); exist {
 		return proxy, rule, nil
 	}
 
 	// metadata may be changed, for example dst ip. original metadata is used as cache key
-	originMetadata := metadata.DeepCopy()
 
 	var resolved bool
 
@@ -312,11 +312,11 @@ func (t *Tunnel) match(metadata *C.Metadata) (C.Proxy, C.Rule, error) {
 				log.Debugln("%v UDP is not supported", adapter.Name())
 				continue
 			}
-			t.ruleMatchCache.Put(originMetadata, adapter, rule)
+			t.ruleMatchCache.Put(key, adapter, rule)
 			return adapter, rule, nil
 		}
 	}
-	t.ruleMatchCache.Put(originMetadata, t.proxies["DIRECT"], nil)
+	t.ruleMatchCache.Put(key, t.proxies["DIRECT"], nil)
 	return t.proxies["DIRECT"], nil, nil
 }
 


### PR DESCRIPTION
Add rule match result cache to speed up it when there are many rules. For example, use 
dnsmasq-china-list  to domain rule match