### PR TITLE
Increase DNS timeout

### DIFF
--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -180,7 +180,7 @@ func (r *Resolver) IsFakeIP(ip net.IP) bool {
 }
 
 func (r *Resolver) batchExchange(clients []resolver, m *D.Msg) (msg *D.Msg, err error) {
-	fast, ctx := picker.WithTimeout(context.Background(), time.Second)
+	fast, ctx := picker.WithTimeout(context.Background(), time.Second * 5)
 	for _, client := range clients {
 		r := client
 		fast.Go(func() (interface{}, error) {


### PR DESCRIPTION
日常用下来，即便是国内的域名解析，也偶尔会遇到超过 1s 解析时间的，DNS 出错搞得有点困扰。
参考 man resolv.conf 默认设置是 5s，应该比较合理

```
timeout:n
    sets  the amount of time the resolver will wait for a response from a remote name server before retrying the query via a different name server.  Measured in seconds, the default is RES_TIMEOUT (currently 5, see <resolv.h>).  The value for this option is silently capped to 30.```