### PR TITLE
[Fix] Let ExchangeContext respond to cancel

### DIFF
--- a/common/picker/picker.go
+++ b/common/picker/picker.go
@@ -59,6 +59,7 @@ func (p *Picker) Wait() interface{} {
 }
 
 // WaitWithoutCancel blocks until the first result return, if timeout will return nil.
+// The return of this function will not wait for the cancel of context.
 func (p *Picker) WaitWithoutCancel() interface{} {
 	select {
 	case <-p.firstDone:

--- a/dns/client.go
+++ b/dns/client.go
@@ -16,6 +16,17 @@ func (c *client) Exchange(m *D.Msg) (msg *D.Msg, err error) {
 }
 
 func (c *client) ExchangeContext(ctx context.Context, m *D.Msg) (msg *D.Msg, err error) {
-	msg, _, err = c.Client.ExchangeContext(ctx, m, c.Address)
-	return
+	// miekg/dns ExchangeContext doesn't respond to context cancel, then clash should take care of it.
+	res := make(chan struct{})
+	go func() {
+		msg, _, err = c.Client.ExchangeContext(ctx, m, c.Address)
+		res <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-res:
+		return
+	}
 }

--- a/dns/client.go
+++ b/dns/client.go
@@ -16,17 +16,7 @@ func (c *client) Exchange(m *D.Msg) (msg *D.Msg, err error) {
 }
 
 func (c *client) ExchangeContext(ctx context.Context, m *D.Msg) (msg *D.Msg, err error) {
-	// miekg/dns ExchangeContext doesn't respond to context cancel, then clash should take care of it.
-	res := make(chan struct{})
-	go func() {
-		msg, _, err = c.Client.ExchangeContext(ctx, m, c.Address)
-		res <- struct{}{}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-res:
-		return
-	}
+	// Please note that miekg/dns ExchangeContext doesn't respond to context cancel.
+	msg, _, err = c.Client.ExchangeContext(ctx, m, c.Address)
+	return
 }

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -180,7 +180,7 @@ func (r *Resolver) IsFakeIP(ip net.IP) bool {
 }
 
 func (r *Resolver) batchExchange(clients []resolver, m *D.Msg) (msg *D.Msg, err error) {
-	fast, ctx := picker.WithTimeout(context.Background(), time.Second * 5)
+	fast, ctx := picker.WithTimeout(context.Background(), time.Second*5)
 	for _, client := range clients {
 		r := client
 		fast.Go(func() (interface{}, error) {

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -192,7 +192,7 @@ func (r *Resolver) batchExchange(clients []resolver, m *D.Msg) (msg *D.Msg, err 
 		})
 	}
 
-	elm := fast.Wait()
+	elm := fast.WaitWithoutCancel()
 	if elm == nil {
 		return nil, errors.New("All DNS requests failed")
 	}

--- a/dns/util.go
+++ b/dns/util.go
@@ -134,6 +134,7 @@ func transform(servers []NameServer) []resolver {
 					NextProtos: []string{"dns"},
 				},
 				UDPSize: 4096,
+				Timeout: 5 * time.Second,
 			},
 			Address: s.Addr,
 		})


### PR DESCRIPTION
Clash DNS is designed to pick the first non-nil response from upstream DNS as the response. 

https://github.com/Dreamacro/clash/blob/86d3d77a7f15f8dfc81f68add51cba4f84eb591e/dns/resolver.go#L183-L195

But actually, the picker doesn't work because miekg/dns doesn't respond to context cancel when calling [ExchangeContext](https://github.com/miekg/dns/blob/fbd426fefa88dae28c9ee1349b95c792379a6068/client.go#L400-L415).

Clash should wrap `ExchangeContext` or replace ` elm := fast.Wait()` with `fast.WaitWithoutCancel`

