### PR TITLE
[Feature] Add Reset Statistic API

### DIFF
--- a/tunnel/manager.go
+++ b/tunnel/manager.go
@@ -61,6 +61,15 @@ func (m *Manager) Snapshot() *Snapshot {
 	}
 }
 
+func (m *Manager) ResetStatistic() {
+	m.uploadTemp = 0
+	m.uploadBlip = 0
+	m.uploadTotal = 0
+	m.downloadTemp = 0
+	m.downloadBlip = 0
+	m.downloadTotal = 0
+}
+
 func (m *Manager) handle() {
 	go m.handleCh(m.upload, &m.uploadTemp, &m.uploadBlip, &m.uploadTotal)
 	go m.handleCh(m.download, &m.downloadTemp, &m.downloadBlip, &m.downloadTotal)


### PR DESCRIPTION
又又又是 Clash for Android (

添加一个清除统计信息的 API (

Clash for Android 启动/关闭 代理不会结束 Clash 进程 (
需要一个 API 来重置统计信息 (