### PR TITLE
Feature: add configuration test

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,12 +63,11 @@ func main() {
 
 	if testConfig {
 		if _, err := executor.Parse(); err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
+			log.Errorln(err.Error())
 			fmt.Printf("configuration file %s test failed\n", constant.Path.Config())
 			os.Exit(1)
-		} else {
-			fmt.Printf("configuration file %s test is successful\n", constant.Path.Config())
 		}
+		fmt.Printf("configuration file %s test is successful\n", constant.Path.Config())
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -62,8 +62,6 @@ func main() {
 	}
 
 	if testConfig {
-		// silence INFO logs during config parsing
-		log.SetLevel(log.WARNING)
 		if _, err := executor.Parse(); err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			fmt.Printf("configuration file %s test failed\n", constant.Path.Config())

--- a/main.go
+++ b/main.go
@@ -10,13 +10,16 @@ import (
 	"syscall"
 
 	"github.com/Dreamacro/clash/config"
+	"github.com/Dreamacro/clash/constant"
 	C "github.com/Dreamacro/clash/constant"
 	"github.com/Dreamacro/clash/hub"
+	"github.com/Dreamacro/clash/hub/executor"
 	"github.com/Dreamacro/clash/log"
 )
 
 var (
 	version    bool
+	testConfig bool
 	homeDir    string
 	configFile string
 )
@@ -25,6 +28,7 @@ func init() {
 	flag.StringVar(&homeDir, "d", "", "set configuration directory")
 	flag.StringVar(&configFile, "f", "", "specify configuration file")
 	flag.BoolVar(&version, "v", false, "show current version of clash")
+	flag.BoolVar(&testConfig, "t", false, "test configuration and exit")
 	flag.Parse()
 }
 
@@ -55,6 +59,19 @@ func main() {
 
 	if err := config.Init(C.Path.HomeDir()); err != nil {
 		log.Fatalln("Initial configuration directory error: %s", err.Error())
+	}
+
+	if testConfig {
+		// silence INFO logs during config parsing
+		log.SetLevel(log.WARNING)
+		if _, err := executor.Parse(); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Printf("configuration file %s test failed\n", constant.Path.Config())
+			os.Exit(1)
+		} else {
+			fmt.Printf("configuration file %s test is successful\n", constant.Path.Config())
+		}
+		return
 	}
 
 	if err := hub.Parse(); err != nil {


### PR DESCRIPTION
I generate clash config with [clash-config-preprocessor](https://github.com/whtsky/clash-config-preprocessor/). Sometimes the generated config file is invalid due to upstream rule-set changes, so it would be nice to have the configuration file test feature built-in.

The cli design is highly influenced by `nginx -t`.