### PR TITLE
[Feature] [TCP only] Support relay (proxy chains)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ proxies:
     # skip-cert-verify: true
 
 proxy-groups:
+  # relay chains the proxies. proxies shall not contain a proxy-group. No UDP support.
+  # Traffic: clash <-> http <-> vmess <-> ss1 <-> ss2 <-> Internet
+  - name: "relay"
+    type: relay
+    proxies:
+      - http
+      - vmess
+      - ss1
+      - ss2
+
   # url-test select which proxy will be used by benchmarking speed to a URL.
   - name: "auto"
     type: url-test

--- a/adapters/outbound/base.go
+++ b/adapters/outbound/base.go
@@ -18,6 +18,7 @@ var (
 
 type Base struct {
 	name string
+	addr string
 	tp   C.AdapterType
 	udp  bool
 }
@@ -49,11 +50,11 @@ func (b *Base) MarshalJSON() ([]byte, error) {
 }
 
 func (b *Base) Addr() string {
-	return ""
+	return b.addr
 }
 
-func NewBase(name string, tp C.AdapterType, udp bool) *Base {
-	return &Base{name, tp, udp}
+func NewBase(name string, addr string, tp C.AdapterType, udp bool) *Base {
+	return &Base{name, addr, tp, udp}
 }
 
 type conn struct {
@@ -111,20 +112,12 @@ func (p *Proxy) Dial(metadata *C.Metadata) (C.Conn, error) {
 	return p.DialContext(ctx, metadata)
 }
 
-func (p *Proxy) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
-	return p.ProxyAdapter.StreamConn(c, metadata)
-}
-
 func (p *Proxy) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
 	conn, err := p.ProxyAdapter.DialContext(ctx, metadata)
 	if err != nil {
 		p.alive = false
 	}
 	return conn, err
-}
-
-func (p *Proxy) Addr() string {
-	return p.ProxyAdapter.Addr()
 }
 
 func (p *Proxy) DelayHistory() []C.DelayHistory {

--- a/adapters/outbound/direct.go
+++ b/adapters/outbound/direct.go
@@ -24,7 +24,7 @@ func (d *Direct) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn,
 		return nil, err
 	}
 	tcpKeepAlive(c)
-	return newConn(c, d), nil
+	return NewConn(c, d), nil
 }
 
 func (d *Direct) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {

--- a/adapters/outbound/http.go
+++ b/adapters/outbound/http.go
@@ -19,7 +19,6 @@ import (
 
 type Http struct {
 	*Base
-	addr      string
 	user      string
 	pass      string
 	tlsConfig *tls.Config
@@ -64,10 +63,6 @@ func (h *Http) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, e
 	}
 
 	return NewConn(c, h), nil
-}
-
-func (h *Http) Addr() string {
-	return h.addr
 }
 
 func (h *Http) shakeHand(metadata *C.Metadata, rw io.ReadWriter) error {
@@ -129,9 +124,9 @@ func NewHttp(option HttpOption) *Http {
 	return &Http{
 		Base: &Base{
 			name: option.Name,
+			addr: net.JoinHostPort(option.Server, strconv.Itoa(option.Port)),
 			tp:   C.Http,
 		},
-		addr:      net.JoinHostPort(option.Server, strconv.Itoa(option.Port)),
 		user:      option.UserName,
 		pass:      option.Password,
 		tlsConfig: tlsConfig,

--- a/adapters/outbound/reject.go
+++ b/adapters/outbound/reject.go
@@ -15,7 +15,7 @@ type Reject struct {
 }
 
 func (r *Reject) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	return newConn(&NopConn{}, r), nil
+	return NewConn(&NopConn{}, r), nil
 }
 
 func (r *Reject) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {

--- a/adapters/outbound/shadowsocks.go
+++ b/adapters/outbound/shadowsocks.go
@@ -21,9 +21,8 @@ import (
 
 type ShadowSocks struct {
 	*Base
-	server   string
-	metadata *C.Metadata
-	cipher   core.Cipher
+	server string
+	cipher core.Cipher
 
 	// obfs
 	obfsMode    string

--- a/adapters/outbound/snell.go
+++ b/adapters/outbound/snell.go
@@ -15,7 +15,6 @@ import (
 
 type Snell struct {
 	*Base
-	server     string
 	psk        []byte
 	obfsOption *simpleObfsOption
 }
@@ -33,7 +32,7 @@ func (s *Snell) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 	case "tls":
 		c = obfs.NewTLSObfs(c, s.obfsOption.Host)
 	case "http":
-		_, port, _ := net.SplitHostPort(s.server)
+		_, port, _ := net.SplitHostPort(s.addr)
 		c = obfs.NewHTTPObfs(c, s.obfsOption.Host, port)
 	}
 	c = snell.StreamConn(c, s.psk)
@@ -43,9 +42,9 @@ func (s *Snell) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (s *Snell) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", s.server)
+	c, err := dialer.DialContext(ctx, "tcp", s.addr)
 	if err != nil {
-		return nil, fmt.Errorf("%s connect error: %w", s.server, err)
+		return nil, fmt.Errorf("%s connect error: %w", s.addr, err)
 	}
 	tcpKeepAlive(c)
 
@@ -53,30 +52,26 @@ func (s *Snell) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 	return NewConn(c, s), err
 }
 
-func (s *Snell) Addr() string {
-	return s.server
-}
-
 func NewSnell(option SnellOption) (*Snell, error) {
-	server := net.JoinHostPort(option.Server, strconv.Itoa(option.Port))
+	addr := net.JoinHostPort(option.Server, strconv.Itoa(option.Port))
 	psk := []byte(option.Psk)
 
 	decoder := structure.NewDecoder(structure.Option{TagName: "obfs", WeaklyTypedInput: true})
 	obfsOption := &simpleObfsOption{Host: "bing.com"}
 	if err := decoder.Decode(option.ObfsOpts, obfsOption); err != nil {
-		return nil, fmt.Errorf("snell %s initialize obfs error: %w", server, err)
+		return nil, fmt.Errorf("snell %s initialize obfs error: %w", addr, err)
 	}
 
 	if obfsOption.Mode != "tls" && obfsOption.Mode != "http" {
-		return nil, fmt.Errorf("snell %s obfs mode error: %s", server, obfsOption.Mode)
+		return nil, fmt.Errorf("snell %s obfs mode error: %s", addr, obfsOption.Mode)
 	}
 
 	return &Snell{
 		Base: &Base{
 			name: option.Name,
+			addr: addr,
 			tp:   C.Snell,
 		},
-		server:     server,
 		psk:        psk,
 		obfsOption: obfsOption,
 	}, nil

--- a/adapters/outbound/snell.go
+++ b/adapters/outbound/snell.go
@@ -28,15 +28,6 @@ type SnellOption struct {
 	ObfsOpts map[string]interface{} `proxy:"obfs-opts,omitempty"`
 }
 
-func (s *Snell) InitConn(ctx context.Context) (net.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", s.server)
-	if err != nil {
-		return nil, fmt.Errorf("%s connect error: %w", s.server, err)
-	}
-	tcpKeepAlive(c)
-	return c, nil
-}
-
 func (s *Snell) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 	switch s.obfsOption.Mode {
 	case "tls":
@@ -57,12 +48,13 @@ func (s *Snell) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 		return nil, fmt.Errorf("%s connect error: %w", s.server, err)
 	}
 	tcpKeepAlive(c)
+
 	c, err = s.StreamConn(c, metadata)
 	return NewConn(c, s), err
 }
 
-func (s *Snell) ToMetadata() (C.Metadata, error) {
-	return addressToMetadata(s.server)
+func (s *Snell) Addr() string {
+	return s.server
 }
 
 func NewSnell(option SnellOption) (*Snell, error) {

--- a/adapters/outbound/socks5.go
+++ b/adapters/outbound/socks5.go
@@ -17,7 +17,6 @@ import (
 
 type Socks5 struct {
 	*Base
-	addr           string
 	user           string
 	pass           string
 	tls            bool
@@ -126,10 +125,6 @@ func (ss *Socks5) DialUDP(metadata *C.Metadata) (_ C.PacketConn, err error) {
 	return newPacketConn(&socksPacketConn{PacketConn: pc, rAddr: bindAddr.UDPAddr(), tcpConn: c}, ss), nil
 }
 
-func (ss *Socks5) Addr() string {
-	return ss.addr
-}
-
 func NewSocks5(option Socks5Option) *Socks5 {
 	var tlsConfig *tls.Config
 	if option.TLS {
@@ -143,10 +138,10 @@ func NewSocks5(option Socks5Option) *Socks5 {
 	return &Socks5{
 		Base: &Base{
 			name: option.Name,
+			addr: net.JoinHostPort(option.Server, strconv.Itoa(option.Port)),
 			tp:   C.Socks5,
 			udp:  option.UDP,
 		},
-		addr:           net.JoinHostPort(option.Server, strconv.Itoa(option.Port)),
 		user:           option.UserName,
 		pass:           option.Password,
 		tls:            option.TLS,

--- a/adapters/outbound/socks5.go
+++ b/adapters/outbound/socks5.go
@@ -36,19 +36,25 @@ type Socks5Option struct {
 	SkipCertVerify bool   `proxy:"skip-cert-verify,omitempty"`
 }
 
-func (ss *Socks5) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
+func (ss *Socks5) InitConn(ctx context.Context) (net.Conn, error) {
 	c, err := dialer.DialContext(ctx, "tcp", ss.addr)
-
-	if err == nil && ss.tls {
-		cc := tls.Client(c, ss.tlsConfig)
-		err = cc.Handshake()
-		c = cc
-	}
-
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", ss.addr, err)
 	}
 	tcpKeepAlive(c)
+	return c, nil
+}
+
+func (ss *Socks5) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
+	if ss.tls {
+		cc := tls.Client(c, ss.tlsConfig)
+		err := cc.Handshake()
+		c = cc
+		if err != nil {
+			return nil, fmt.Errorf("%s connect error: %w", ss.addr, err)
+		}
+	}
+
 	var user *socks5.User
 	if ss.user != "" {
 		user = &socks5.User{
@@ -59,7 +65,21 @@ func (ss *Socks5) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn
 	if _, err := socks5.ClientHandshake(c, serializesSocksAddr(metadata), socks5.CmdConnect, user); err != nil {
 		return nil, err
 	}
-	return newConn(c, ss), nil
+	return c, nil
+}
+
+func (ss *Socks5) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
+	c, err := ss.InitConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err = ss.StreamConn(c, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewConn(c, ss), nil
 }
 
 func (ss *Socks5) DialUDP(metadata *C.Metadata) (_ C.PacketConn, err error) {
@@ -112,6 +132,10 @@ func (ss *Socks5) DialUDP(metadata *C.Metadata) (_ C.PacketConn, err error) {
 	}()
 
 	return newPacketConn(&socksPacketConn{PacketConn: pc, rAddr: bindAddr.UDPAddr(), tcpConn: c}, ss), nil
+}
+
+func (ss *Socks5) ToMetadata() (C.Metadata, error) {
+	return addressToMetadata(ss.addr)
 }
 
 func NewSocks5(option Socks5Option) *Socks5 {

--- a/adapters/outbound/util.go
+++ b/adapters/outbound/util.go
@@ -52,42 +52,6 @@ func urlToMetadata(rawURL string) (addr C.Metadata, err error) {
 	return
 }
 
-func addressToMetadata(rawAddress string) (addr C.Metadata, err error) {
-	host, port, err := net.SplitHostPort(rawAddress)
-	if err != nil {
-		return
-	}
-
-	ip := net.ParseIP(host)
-	if ip != nil {
-		if ip.To4() != nil {
-			addr = C.Metadata{
-				AddrType: C.AtypIPv4,
-				Host:     "",
-				DstIP:    ip,
-				DstPort:  port,
-			}
-			return
-		} else {
-			addr = C.Metadata{
-				AddrType: C.AtypIPv6,
-				Host:     "",
-				DstIP:    ip,
-				DstPort:  port,
-			}
-			return
-		}
-	} else {
-		addr = C.Metadata{
-			AddrType: C.AtypDomainName,
-			Host:     host,
-			DstIP:    nil,
-			DstPort:  port,
-		}
-		return
-	}
-}
-
 func tcpKeepAlive(c net.Conn) {
 	if tcp, ok := c.(*net.TCPConn); ok {
 		tcp.SetKeepAlive(true)

--- a/adapters/outbound/util.go
+++ b/adapters/outbound/util.go
@@ -52,6 +52,42 @@ func urlToMetadata(rawURL string) (addr C.Metadata, err error) {
 	return
 }
 
+func addressToMetadata(rawAddress string) (addr C.Metadata, err error) {
+	host, port, err := net.SplitHostPort(rawAddress)
+	if err != nil {
+		return
+	}
+
+	ip := net.ParseIP(host)
+	if ip != nil {
+		if ip.To4() != nil {
+			addr = C.Metadata{
+				AddrType: C.AtypIPv4,
+				Host:     "",
+				DstIP:    ip,
+				DstPort:  port,
+			}
+			return
+		} else {
+			addr = C.Metadata{
+				AddrType: C.AtypIPv6,
+				Host:     "",
+				DstIP:    ip,
+				DstPort:  port,
+			}
+			return
+		}
+	} else {
+		addr = C.Metadata{
+			AddrType: C.AtypDomainName,
+			Host:     host,
+			DstIP:    nil,
+			DstPort:  port,
+		}
+		return
+	}
+}
+
 func tcpKeepAlive(c net.Conn) {
 	if tcp, ok := c.(*net.TCPConn); ok {
 		tcp.SetKeepAlive(true)

--- a/adapters/outboundgroup/fallback.go
+++ b/adapters/outboundgroup/fallback.go
@@ -77,7 +77,7 @@ func (f *Fallback) findAliveProxy() C.Proxy {
 
 func NewFallback(name string, providers []provider.ProxyProvider) *Fallback {
 	return &Fallback{
-		Base:      outbound.NewBase(name, C.Fallback, false),
+		Base:      outbound.NewBase(name, "", C.Fallback, false),
 		single:    singledo.NewSingle(defaultGetProxiesDuration),
 		providers: providers,
 	}

--- a/adapters/outboundgroup/loadbalance.go
+++ b/adapters/outboundgroup/loadbalance.go
@@ -120,7 +120,7 @@ func (lb *LoadBalance) MarshalJSON() ([]byte, error) {
 
 func NewLoadBalance(name string, providers []provider.ProxyProvider) *LoadBalance {
 	return &LoadBalance{
-		Base:      outbound.NewBase(name, C.LoadBalance, false),
+		Base:      outbound.NewBase(name, "", C.LoadBalance, false),
 		single:    singledo.NewSingle(defaultGetProxiesDuration),
 		maxRetry:  3,
 		providers: providers,

--- a/adapters/outboundgroup/parser.go
+++ b/adapters/outboundgroup/parser.go
@@ -64,7 +64,7 @@ func ParseProxyGroup(config map[string]interface{}, proxyMap map[string]C.Proxy,
 			providers = append(providers, pd)
 		} else {
 			// select don't need health check
-			if groupOption.Type == "select" {
+			if groupOption.Type == "select" || groupOption.Type == "relay" {
 				hc := provider.NewHealthCheck(ps, "", 0)
 				pd, err := provider.NewCompatibleProvider(groupName, ps, hc)
 				if err != nil {
@@ -108,6 +108,8 @@ func ParseProxyGroup(config map[string]interface{}, proxyMap map[string]C.Proxy,
 		group = NewFallback(groupName, providers)
 	case "load-balance":
 		group = NewLoadBalance(groupName, providers)
+	case "relay":
+		group = NewRelay(groupName, providers)
 	default:
 		return nil, fmt.Errorf("%w: %s", errType, groupOption.Type)
 	}

--- a/adapters/outboundgroup/relay.go
+++ b/adapters/outboundgroup/relay.go
@@ -1,0 +1,81 @@
+package outboundgroup
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/Dreamacro/clash/adapters/outbound"
+	"github.com/Dreamacro/clash/adapters/provider"
+	"github.com/Dreamacro/clash/common/singledo"
+	C "github.com/Dreamacro/clash/constant"
+)
+
+type Relay struct {
+	*outbound.Base
+	single    *singledo.Single
+	providers []provider.ProxyProvider
+}
+
+func (r *Relay) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
+	proxies := r.proxies()
+	proxyAdapterExtendeds := make([]C.ProxyAdapterExtended, len(proxies))
+	for i, proxy := range proxies {
+		proxyAdapterExtendeds[i] = proxy.(C.ProxyAdapterExtended)
+	}
+
+	c, err := proxyAdapterExtendeds[0].InitConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyMeta := make([]C.Metadata, len(proxyAdapterExtendeds))
+	for i := 0; i < len(proxyAdapterExtendeds) - 1; i++ {
+		proxyMeta[i], err = proxyAdapterExtendeds[i+1].ToMetadata()
+		if err != nil {
+			return nil, err
+		}
+		c, err = proxyAdapterExtendeds[i].StreamConn(c, &proxyMeta[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	c, err = proxyAdapterExtendeds[len(proxyAdapterExtendeds)-1].StreamConn(c, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	cc := outbound.NewConn(c, proxyAdapterExtendeds[0])
+	cc.AppendToChains(r)
+	return cc, nil
+}
+
+func (r *Relay) SupportUDP() bool {
+	return false
+}
+
+func (r *Relay) MarshalJSON() ([]byte, error) {
+	var all []string
+	for _, proxy := range r.proxies() {
+		all = append(all, proxy.Name())
+	}
+	return json.Marshal(map[string]interface{}{
+		"type": r.Type().String(),
+		"all":  all,
+	})
+}
+
+func (r *Relay) proxies() []C.Proxy {
+	elm, _, _ := r.single.Do(func() (interface{}, error) {
+		return getProvidersProxies(r.providers), nil
+	})
+
+	return elm.([]C.Proxy)
+}
+
+func NewRelay(name string, providers []provider.ProxyProvider) *Relay {
+	return &Relay{
+		Base:      outbound.NewBase(name, C.Relay, false),
+		single:    singledo.NewSingle(defaultGetProxiesDuration),
+		providers: providers,
+	}
+}

--- a/adapters/outboundgroup/relay.go
+++ b/adapters/outboundgroup/relay.go
@@ -53,9 +53,7 @@ func (r *Relay) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 		return nil, fmt.Errorf("%s connect error: %w", last.Addr(), err)
 	}
 
-	cc := outbound.NewConn(c, proxies[0])
-	cc.AppendToChains(r)
-	return cc, nil
+	return outbound.NewConn(c, r), nil
 }
 
 func (r *Relay) MarshalJSON() ([]byte, error) {

--- a/adapters/outboundgroup/selector.go
+++ b/adapters/outboundgroup/selector.go
@@ -77,7 +77,7 @@ func (s *Selector) proxies() []C.Proxy {
 func NewSelector(name string, providers []provider.ProxyProvider) *Selector {
 	selected := providers[0].Proxies()[0]
 	return &Selector{
-		Base:      outbound.NewBase(name, C.Selector, false),
+		Base:      outbound.NewBase(name, "", C.Selector, false),
 		single:    singledo.NewSingle(defaultGetProxiesDuration),
 		providers: providers,
 		selected:  selected,

--- a/adapters/outboundgroup/urltest.go
+++ b/adapters/outboundgroup/urltest.go
@@ -86,7 +86,7 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 
 func NewURLTest(name string, providers []provider.ProxyProvider) *URLTest {
 	return &URLTest{
-		Base:       outbound.NewBase(name, C.URLTest, false),
+		Base:       outbound.NewBase(name, "", C.URLTest, false),
 		single:     singledo.NewSingle(defaultGetProxiesDuration),
 		fastSingle: singledo.NewSingle(time.Second * 10),
 		providers:  providers,

--- a/adapters/outboundgroup/util.go
+++ b/adapters/outboundgroup/util.go
@@ -9,40 +9,40 @@ import (
 )
 
 func addrToMetadata(rawAddress string) (addr *C.Metadata, err error) {
-        host, port, err := net.SplitHostPort(rawAddress)
-        if err != nil {
-                err = fmt.Errorf("addrToMetadata failed: %w", err)
-                return
-        }
+	host, port, err := net.SplitHostPort(rawAddress)
+	if err != nil {
+		err = fmt.Errorf("addrToMetadata failed: %w", err)
+		return
+	}
 
-        ip := net.ParseIP(host)
-        if ip != nil {
-                if ip.To4() != nil {
-                        addr = &C.Metadata{
-                                AddrType: C.AtypIPv4,
-                                Host:     "",
-                                DstIP:    ip,
-                                DstPort:  port,
-                        }
-                        return
-                } else {
-                        addr = &C.Metadata{
-                                AddrType: C.AtypIPv6,
-                                Host:     "",
-                                DstIP:    ip,
-                                DstPort:  port,
-                        }
-                        return
-                }
-        } else {
+	ip := net.ParseIP(host)
+	if ip != nil {
+		if ip.To4() != nil {
+			addr = &C.Metadata{
+				AddrType: C.AtypIPv4,
+				Host:     "",
+				DstIP:    ip,
+				DstPort:  port,
+			}
+			return
+		} else {
+			addr = &C.Metadata{
+				AddrType: C.AtypIPv6,
+				Host:     "",
+				DstIP:    ip,
+				DstPort:  port,
+			}
+			return
+		}
+	} else {
 		addr = &C.Metadata{
-                        AddrType: C.AtypDomainName,
-                        Host:     host,
-                        DstIP:    nil,
-                        DstPort:  port,
-                }
-                return
-        }
+			AddrType: C.AtypDomainName,
+			Host:     host,
+			DstIP:    nil,
+			DstPort:  port,
+		}
+		return
+	}
 }
 
 func tcpKeepAlive(c net.Conn) {

--- a/adapters/outboundgroup/util.go
+++ b/adapters/outboundgroup/util.go
@@ -1,0 +1,53 @@
+package outboundgroup
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	C "github.com/Dreamacro/clash/constant"
+)
+
+func addrToMetadata(rawAddress string) (addr *C.Metadata, err error) {
+        host, port, err := net.SplitHostPort(rawAddress)
+        if err != nil {
+                err = fmt.Errorf("addrToMetadata failed: %w", err)
+                return
+        }
+
+        ip := net.ParseIP(host)
+        if ip != nil {
+                if ip.To4() != nil {
+                        addr = &C.Metadata{
+                                AddrType: C.AtypIPv4,
+                                Host:     "",
+                                DstIP:    ip,
+                                DstPort:  port,
+                        }
+                        return
+                } else {
+                        addr = &C.Metadata{
+                                AddrType: C.AtypIPv6,
+                                Host:     "",
+                                DstIP:    ip,
+                                DstPort:  port,
+                        }
+                        return
+                }
+        } else {
+		addr = &C.Metadata{
+                        AddrType: C.AtypDomainName,
+                        Host:     host,
+                        DstIP:    nil,
+                        DstPort:  port,
+                }
+                return
+        }
+}
+
+func tcpKeepAlive(c net.Conn) {
+	if tcp, ok := c.(*net.TCPConn); ok {
+		tcp.SetKeepAlive(true)
+		tcp.SetKeepAlivePeriod(30 * time.Second)
+	}
+}

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -63,17 +63,12 @@ type PacketConn interface {
 type ProxyAdapter interface {
 	Name() string
 	Type() AdapterType
+	StreamConn(c net.Conn, metadata *Metadata) (net.Conn, error)
 	DialContext(ctx context.Context, metadata *Metadata) (Conn, error)
 	DialUDP(metadata *Metadata) (PacketConn, error)
 	SupportUDP() bool
 	MarshalJSON() ([]byte, error)
-}
-
-type ProxyAdapterExtended interface {
-	ProxyAdapter
-	ToMetadata() (Metadata, error)
-	InitConn(ctx context.Context) (net.Conn, error)
-	StreamConn(c net.Conn, metadata *Metadata) (net.Conn, error)
+	Addr() string
 }
 
 type DelayHistory struct {

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -19,6 +19,7 @@ const (
 	Vmess
 	Trojan
 
+	Relay
 	Selector
 	Fallback
 	URLTest
@@ -68,6 +69,13 @@ type ProxyAdapter interface {
 	MarshalJSON() ([]byte, error)
 }
 
+type ProxyAdapterExtended interface {
+	ProxyAdapter
+	ToMetadata() (Metadata, error)
+	InitConn(ctx context.Context) (net.Conn, error)
+	StreamConn(c net.Conn, metadata *Metadata) (net.Conn, error)
+}
+
 type DelayHistory struct {
 	Time  time.Time `json:"time"`
 	Delay uint16    `json:"delay"`
@@ -105,6 +113,8 @@ func (at AdapterType) String() string {
 	case Trojan:
 		return "Trojan"
 
+	case Relay:
+		return "Relay"
 	case Selector:
 		return "Selector"
 	case Fallback:


### PR DESCRIPTION
#434

config:
```yaml
proxy-groups:
- name: "relay"
  type: relay
  proxies:
    - http1
    - vmess1
    - ss1
    - ss2
```
traffic:
`clash <-> http1 <-> vmess1 <-> ss1 <-> ss2 <-> Internet`