### PR TITLE
Fix UDP NAT type for TPROXY

### DIFF
--- a/proxy/redir/utils.go
+++ b/proxy/redir/utils.go
@@ -53,8 +53,13 @@ func (c *fakeConn) IpMapped() bool {
 		return *c.ipMapped
 	}
 
-	resolver := resolver.DefaultResolver.(*dns.Resolver)
-	_, ipMapped := resolver.IPToHost(c.origDst.(*net.UDPAddr).IP)
+	var ipMapped bool
+	resolver, ok := resolver.DefaultResolver.(*dns.Resolver)
+	if ok {
+		_, ipMapped = resolver.IPToHost(c.origDst.(*net.UDPAddr).IP)
+	} else {
+		ipMapped = false
+	}
 	c.ipMapped = &ipMapped
 	return ipMapped
 }

--- a/proxy/redir/utils.go
+++ b/proxy/redir/utils.go
@@ -18,7 +18,7 @@ func (c *fakeConn) Data() []byte {
 
 // WriteBack opens a new socket binding `lAddr` to wirte UDP packet back
 func (c *fakeConn) WriteBack(b []byte, addr net.Addr) (n int, err error) {
-	tc, err := dialUDP("udp", c.lAddr, addr.(*net.UDPAddr))
+	tc, err := dialUDP("udp", addr.(*net.UDPAddr), c.lAddr)
 	if err != nil {
 		n = 0
 		return

--- a/proxy/redir/utils.go
+++ b/proxy/redir/utils.go
@@ -16,7 +16,7 @@ func (c *fakeConn) Data() []byte {
 	return c.buf
 }
 
-// WriteBack opens a new socket binding `lAddr` to wirte UDP packet back
+// WriteBack opens a new socket binding `addr` to wirte UDP packet back
 func (c *fakeConn) WriteBack(b []byte, addr net.Addr) (n int, err error) {
 	tc, err := dialUDP("udp", addr.(*net.UDPAddr), c.lAddr)
 	if err != nil {

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -88,7 +88,7 @@ func handleUDPToRemote(packet C.UDPPacket, pc C.PacketConn, metadata *C.Metadata
 	DefaultManager.Upload() <- int64(len(packet.Data()))
 }
 
-func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string) {
+func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, fAddr net.Addr) {
 	buf := pool.BufPool.Get().([]byte)
 	defer pool.BufPool.Put(buf[:cap(buf)])
 	defer natTable.Delete(key)
@@ -99,6 +99,10 @@ func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string) {
 		n, from, err := pc.ReadFrom(buf)
 		if err != nil {
 			return
+		}
+
+		if fAddr != nil {
+			from = fAddr
 		}
 
 		n, err = packet.WriteBack(buf[:n], from)

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -182,6 +182,12 @@ func handleUDPConn(packet *inbound.PacketAdapter) {
 		return
 	}
 
+	// make a fAddr if requset ip is fakeip
+	var fAddr net.Addr
+	if enhancedMode != nil && enhancedMode.IsFakeIP(metadata.DstIP) {
+		fAddr = metadata.UDPAddr()
+	}
+
 	if err := preHandleMetadata(metadata); err != nil {
 		log.Debugln("[Metadata PreHandle] error: %s", err)
 		return
@@ -231,7 +237,7 @@ func handleUDPConn(packet *inbound.PacketAdapter) {
 			natTable.Set(key, pc)
 			natTable.Delete(lockKey)
 			wg.Done()
-			go handleUDPToLocal(packet.UDPPacket, pc, key)
+			go handleUDPToLocal(packet.UDPPacket, pc, key, fAddr)
 		}
 
 		wg.Wait()


### PR DESCRIPTION
This pr is inspired by 9010090800663aa0449e88888b9ede8ffb3361b6. It improves UDP NAT behavior for TPROXY(#562).
### details
In `WriteBack` function, the socket should bind to `origDst` only if `origDst` maps to a host(fake-ip or redir-host mode). Otherwise it'll be ok to bind to `addr`(the real source of the UDP packet to write back).