### PR TITLE
feature: support matching multi-level sub-domain in fake-dns-filter

### DIFF
--- a/component/domain-trie/tire.go
+++ b/component/domain-trie/tire.go
@@ -6,6 +6,7 @@ import (
 )
 
 const (
+	longwildcard = "**"
 	wildcard   = "*"
 	domainStep = "."
 )
@@ -67,6 +68,9 @@ func (t *Trie) Search(domain string) *Node {
 
 		var child *Node
 		if !n.hasChild(part) {
+			if n.hasChild(longwildcard) {
+				return n
+			}
 			if !n.hasChild(wildcard) {
 				return nil
 			}


### PR DESCRIPTION
Fix #473
Adding a long wildcard '**' in fake-dns-filter matching process.
So the Search priority will change to:
1. static part (keep still)
2. long wildcard domain (NEW)
3. wildcard domain