### PR TITLE
Feature: support proxy-group in relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ proxies:
     # skip-cert-verify: true
 
 proxy-groups:
-  # relay chains the proxies. proxies shall not contain a proxy-group. No UDP support.
+  # relay chains the proxies. proxies shall not contain a relay. No UDP support.
   # Traffic: clash <-> http <-> vmess <-> ss1 <-> ss2 <-> Internet
   - name: "relay"
     type: relay

--- a/adapters/outbound/base.go
+++ b/adapters/outbound/base.go
@@ -53,7 +53,7 @@ func (b *Base) Addr() string {
 	return b.addr
 }
 
-func (b *Base) Proxy(metadata *C.Metadata) C.Proxy {
+func (b *Base) Unwrap(metadata *C.Metadata) C.Proxy {
 	return nil
 }
 

--- a/adapters/outbound/base.go
+++ b/adapters/outbound/base.go
@@ -53,6 +53,10 @@ func (b *Base) Addr() string {
 	return b.addr
 }
 
+func (b *Base) Proxy() C.Proxy {
+	return nil
+}
+
 func NewBase(name string, addr string, tp C.AdapterType, udp bool) *Base {
 	return &Base{name, addr, tp, udp}
 }

--- a/adapters/outbound/base.go
+++ b/adapters/outbound/base.go
@@ -53,7 +53,7 @@ func (b *Base) Addr() string {
 	return b.addr
 }
 
-func (b *Base) Proxy() C.Proxy {
+func (b *Base) Proxy(metadata *C.Metadata) C.Proxy {
 	return nil
 }
 

--- a/adapters/outboundgroup/fallback.go
+++ b/adapters/outboundgroup/fallback.go
@@ -56,6 +56,11 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (f *Fallback) Proxy() C.Proxy {
+	proxy := f.findAliveProxy()
+	return proxy
+}
+
 func (f *Fallback) proxies() []C.Proxy {
 	elm, _, _ := f.single.Do(func() (interface{}, error) {
 		return getProvidersProxies(f.providers), nil

--- a/adapters/outboundgroup/fallback.go
+++ b/adapters/outboundgroup/fallback.go
@@ -56,7 +56,7 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (f *Fallback) Proxy() C.Proxy {
+func (f *Fallback) Proxy(metadata *C.Metadata) C.Proxy {
 	proxy := f.findAliveProxy()
 	return proxy
 }

--- a/adapters/outboundgroup/fallback.go
+++ b/adapters/outboundgroup/fallback.go
@@ -56,7 +56,7 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (f *Fallback) Proxy(metadata *C.Metadata) C.Proxy {
+func (f *Fallback) Unwrap(metadata *C.Metadata) C.Proxy {
 	proxy := f.findAliveProxy()
 	return proxy
 }

--- a/adapters/outboundgroup/loadbalance.go
+++ b/adapters/outboundgroup/loadbalance.go
@@ -59,7 +59,7 @@ func (lb *LoadBalance) DialContext(ctx context.Context, metadata *C.Metadata) (c
 		}
 	}()
 
-	proxy := lb.Proxy(metadata)
+	proxy := lb.Unwrap(metadata)
 
 	c, err = proxy.DialContext(ctx, metadata)
 	return
@@ -72,7 +72,7 @@ func (lb *LoadBalance) DialUDP(metadata *C.Metadata) (pc C.PacketConn, err error
 		}
 	}()
 
-	proxy := lb.Proxy(metadata)
+	proxy := lb.Unwrap(metadata)
 
 	return proxy.DialUDP(metadata)
 }
@@ -81,7 +81,7 @@ func (lb *LoadBalance) SupportUDP() bool {
 	return true
 }
 
-func (lb *LoadBalance) Proxy(metadata *C.Metadata) C.Proxy {
+func (lb *LoadBalance) Unwrap(metadata *C.Metadata) C.Proxy {
 	key := uint64(murmur3.Sum32([]byte(getKey(metadata))))
 	proxies := lb.proxies()
 	buckets := int32(len(proxies))

--- a/adapters/outboundgroup/relay.go
+++ b/adapters/outboundgroup/relay.go
@@ -79,10 +79,10 @@ func (r *Relay) proxies(metadata *C.Metadata) []C.Proxy {
 	proxies := r.rawProxies()
 
 	for n, proxy := range proxies {
-		subproxy := proxy.Proxy(metadata)
+		subproxy := proxy.Unwrap(metadata)
 		for subproxy != nil {
 			proxies[n] = subproxy
-			subproxy = subproxy.Proxy(metadata)
+			subproxy = subproxy.Unwrap(metadata)
 		}
 	}
 

--- a/adapters/outboundgroup/relay.go
+++ b/adapters/outboundgroup/relay.go
@@ -58,7 +58,7 @@ func (r *Relay) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, 
 
 func (r *Relay) MarshalJSON() ([]byte, error) {
 	var all []string
-	for _, proxy := range r.proxies() {
+	for _, proxy := range r.rawProxies() {
 		all = append(all, proxy.Name())
 	}
 	return json.Marshal(map[string]interface{}{
@@ -67,12 +67,26 @@ func (r *Relay) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (r *Relay) proxies() []C.Proxy {
+func (r *Relay) rawProxies() []C.Proxy {
 	elm, _, _ := r.single.Do(func() (interface{}, error) {
 		return getProvidersProxies(r.providers), nil
 	})
 
 	return elm.([]C.Proxy)
+}
+
+func (r *Relay) proxies() []C.Proxy {
+	proxies := r.rawProxies()
+
+	for n, proxy := range proxies {
+		subproxy := proxy.Proxy()
+		for subproxy != nil {
+			proxies[n] = subproxy
+			subproxy = subproxy.Proxy()
+		}
+	}
+
+	return proxies
 }
 
 func NewRelay(name string, providers []provider.ProxyProvider) *Relay {

--- a/adapters/outboundgroup/relay.go
+++ b/adapters/outboundgroup/relay.go
@@ -20,7 +20,7 @@ type Relay struct {
 }
 
 func (r *Relay) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	proxies := r.proxies()
+	proxies := r.proxies(metadata)
 	if len(proxies) == 0 {
 		return nil, errors.New("Proxy does not exist")
 	}
@@ -75,14 +75,14 @@ func (r *Relay) rawProxies() []C.Proxy {
 	return elm.([]C.Proxy)
 }
 
-func (r *Relay) proxies() []C.Proxy {
+func (r *Relay) proxies(metadata *C.Metadata) []C.Proxy {
 	proxies := r.rawProxies()
 
 	for n, proxy := range proxies {
-		subproxy := proxy.Proxy()
+		subproxy := proxy.Proxy(metadata)
 		for subproxy != nil {
 			proxies[n] = subproxy
-			subproxy = subproxy.Proxy()
+			subproxy = subproxy.Proxy(metadata)
 		}
 	}
 

--- a/adapters/outboundgroup/selector.go
+++ b/adapters/outboundgroup/selector.go
@@ -67,6 +67,10 @@ func (s *Selector) Set(name string) error {
 	return errors.New("Proxy does not exist")
 }
 
+func (s *Selector) Proxy() C.Proxy {
+	return s.selectedProxy()
+}
+
 func (s *Selector) selectedProxy() C.Proxy {
 	elm, _, _ := s.single.Do(func() (interface{}, error) {
 		proxies := getProvidersProxies(s.providers)

--- a/adapters/outboundgroup/selector.go
+++ b/adapters/outboundgroup/selector.go
@@ -67,7 +67,7 @@ func (s *Selector) Set(name string) error {
 	return errors.New("Proxy does not exist")
 }
 
-func (s *Selector) Proxy() C.Proxy {
+func (s *Selector) Proxy(metadata *C.Metadata) C.Proxy {
 	return s.selectedProxy()
 }
 

--- a/adapters/outboundgroup/selector.go
+++ b/adapters/outboundgroup/selector.go
@@ -67,7 +67,7 @@ func (s *Selector) Set(name string) error {
 	return errors.New("Proxy does not exist")
 }
 
-func (s *Selector) Proxy(metadata *C.Metadata) C.Proxy {
+func (s *Selector) Unwrap(metadata *C.Metadata) C.Proxy {
 	return s.selectedProxy()
 }
 

--- a/adapters/outboundgroup/urltest.go
+++ b/adapters/outboundgroup/urltest.go
@@ -38,7 +38,7 @@ func (u *URLTest) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
 	return pc, err
 }
 
-func (u *URLTest) Proxy() C.Proxy {
+func (u *URLTest) Proxy(metadata *C.Metadata) C.Proxy {
 	return u.fast()
 }
 

--- a/adapters/outboundgroup/urltest.go
+++ b/adapters/outboundgroup/urltest.go
@@ -38,7 +38,7 @@ func (u *URLTest) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
 	return pc, err
 }
 
-func (u *URLTest) Proxy(metadata *C.Metadata) C.Proxy {
+func (u *URLTest) Unwrap(metadata *C.Metadata) C.Proxy {
 	return u.fast()
 }
 

--- a/adapters/outboundgroup/urltest.go
+++ b/adapters/outboundgroup/urltest.go
@@ -38,6 +38,10 @@ func (u *URLTest) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
 	return pc, err
 }
 
+func (u *URLTest) Proxy() C.Proxy {
+	return u.fast()
+}
+
 func (u *URLTest) proxies() []C.Proxy {
 	elm, _, _ := u.single.Do(func() (interface{}, error) {
 		return getProvidersProxies(u.providers), nil

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -69,7 +69,8 @@ type ProxyAdapter interface {
 	SupportUDP() bool
 	MarshalJSON() ([]byte, error)
 	Addr() string
-	Proxy(metadata *Metadata) Proxy
+	// Unwrap extracts the proxy from a proxy-group. It returns nil when nothing to extract.
+	Unwrap(metadata *Metadata) Proxy
 }
 
 type DelayHistory struct {

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -69,7 +69,7 @@ type ProxyAdapter interface {
 	SupportUDP() bool
 	MarshalJSON() ([]byte, error)
 	Addr() string
-	Proxy() Proxy
+	Proxy(metadata *Metadata) Proxy
 }
 
 type DelayHistory struct {

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -69,6 +69,7 @@ type ProxyAdapter interface {
 	SupportUDP() bool
 	MarshalJSON() ([]byte, error)
 	Addr() string
+	Proxy() Proxy
 }
 
 type DelayHistory struct {


### PR DESCRIPTION
### example

```yaml
proxy-groups:
- name: "select"
  type: select
  proxies:
    - ss1
    - ss2

- name: "relay"
  type: relay
  proxies:
    - select
    - vmess1
```

### known issues

- Healthchecks don't follow the proxy chains.