### PR TITLE
Fix: udp duplicate download traffic & update traffic track

### DIFF
--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -85,7 +85,6 @@ func handleUDPToRemote(packet C.UDPPacket, pc C.PacketConn, metadata *C.Metadata
 	if _, err := pc.WriteWithMetadata(packet.Data(), metadata); err != nil {
 		return
 	}
-	DefaultManager.Upload() <- int64(len(packet.Data()))
 }
 
 func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, fAddr net.Addr) {
@@ -109,7 +108,6 @@ func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, fAddr n
 		if err != nil {
 			return
 		}
-		DefaultManager.Download() <- int64(n)
 	}
 }
 

--- a/tunnel/tracker.go
+++ b/tunnel/tracker.go
@@ -103,6 +103,14 @@ func (ut *udpTracker) WriteTo(b []byte, addr net.Addr) (int, error) {
 	return n, err
 }
 
+func (ut *udpTracker) WriteWithMetadata(p []byte, metadata *C.Metadata) (int, error) {
+	n, err := ut.PacketConn.WriteWithMetadata(p, metadata)
+	upload := int64(n)
+	ut.manager.Upload() <- upload
+	ut.UploadTotal += upload
+	return n, err
+}
+
 func (ut *udpTracker) Close() error {
 	ut.manager.Leave(ut)
 	return ut.PacketConn.Close()


### PR DESCRIPTION
修复 UDP 下载流量重复计算 以及 UDP 上传流量未被 tracker 追踪