### PR TITLE
[Feature] relay: use nested dialer instead of nested DialContext

### DIFF
--- a/adapters/outbound/dialer.go
+++ b/adapters/outbound/dialer.go
@@ -1,0 +1,58 @@
+package outbound
+
+import (
+	"context"
+	"github.com/Dreamacro/clash/component/dialer"
+	"github.com/Dreamacro/clash/component/resolver"
+	C "github.com/Dreamacro/clash/constant"
+	"net"
+	"time"
+)
+
+type rootDialer struct{}
+
+func (r *rootDialer) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, C.Connection, error) {
+	address := net.JoinHostPort(metadata.Host, metadata.DstPort)
+	if metadata.DstIP != nil {
+		address = net.JoinHostPort(metadata.DstIP.String(), metadata.DstPort)
+	}
+
+	c, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if tcp, ok := c.(*net.TCPConn); ok {
+		_ = tcp.SetKeepAlive(true)
+		_ = tcp.SetKeepAlivePeriod(30 * time.Second)
+	}
+
+	return c, newConnection(), nil
+}
+
+func (r *rootDialer) DialUDP(_ *C.Metadata) (C.PacketConn, C.Connection, error) {
+	pc, err := dialer.ListenPacket("udp", "")
+	if err != nil {
+		return nil, nil, err
+	}
+	return &rootPacketConn{pc}, newConnection(), nil
+}
+
+type rootPacketConn struct {
+	net.PacketConn
+}
+
+func (rp *rootPacketConn) WriteWithMetadata(p []byte, metadata *C.Metadata) (n int, err error) {
+	if !metadata.Resolved() {
+		ip, err := resolver.ResolveIP(metadata.Host)
+		if err != nil {
+			return 0, err
+		}
+		metadata.DstIP = ip
+	}
+	return rp.WriteTo(p, metadata.UDPAddr())
+}
+
+func NewRootDialer() C.ProxyDialer {
+	return &rootDialer{}
+}

--- a/adapters/outboundgroup/common.go
+++ b/adapters/outboundgroup/common.go
@@ -1,6 +1,7 @@
 package outboundgroup
 
 import (
+	"context"
 	"time"
 
 	"github.com/Dreamacro/clash/adapters/provider"
@@ -11,10 +12,41 @@ const (
 	defaultGetProxiesDuration = time.Second * 5
 )
 
+type groupDialer struct {
+	C.ProxyAdapter
+	dialer C.ProxyDialer
+}
+
+func (g *groupDialer) DialContext(ctx context.Context, metadata *C.Metadata) (conn C.Conn, connection C.Connection, err error) {
+	conn, connection, err = g.dialer.DialContext(ctx, metadata)
+	if err != nil {
+		return
+	}
+	connection.AppendToChains(g)
+	return
+}
+
+func (g *groupDialer) DialUDP(metadata *C.Metadata) (pc C.PacketConn, connection C.Connection, err error) {
+	pc, connection, err = g.dialer.DialUDP(metadata)
+	if err != nil {
+		return
+	}
+
+	connection.AppendToChains(g)
+	return
+}
+
 func getProvidersProxies(providers []provider.ProxyProvider) []C.Proxy {
 	proxies := []C.Proxy{}
 	for _, provider := range providers {
 		proxies = append(proxies, provider.Proxies()...)
 	}
 	return proxies
+}
+
+func newGroupDialer(group C.ProxyAdapter, dialer C.ProxyDialer) *groupDialer {
+	return &groupDialer{
+		ProxyAdapter: group,
+		dialer:       dialer,
+	}
 }

--- a/adapters/outboundgroup/fallback.go
+++ b/adapters/outboundgroup/fallback.go
@@ -1,7 +1,6 @@
 package outboundgroup
 
 import (
-	"context"
 	"encoding/json"
 
 	"github.com/Dreamacro/clash/adapters/outbound"
@@ -21,22 +20,9 @@ func (f *Fallback) Now() string {
 	return proxy.Name()
 }
 
-func (f *Fallback) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	proxy := f.findAliveProxy()
-	c, err := proxy.DialContext(ctx, metadata)
-	if err == nil {
-		c.AppendToChains(f)
-	}
-	return c, err
-}
-
-func (f *Fallback) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
-	proxy := f.findAliveProxy()
-	pc, err := proxy.DialUDP(metadata)
-	if err == nil {
-		pc.AppendToChains(f)
-	}
-	return pc, err
+func (f *Fallback) Dialer(parent C.ProxyDialer) C.ProxyDialer {
+	p := f.findAliveProxy()
+	return newGroupDialer(f, p.Dialer(parent))
 }
 
 func (f *Fallback) SupportUDP() bool {

--- a/adapters/outboundgroup/relay.go
+++ b/adapters/outboundgroup/relay.go
@@ -45,7 +45,7 @@ func (r *Relay) proxies() []C.Proxy {
 
 func NewRelay(name string, providers []provider.ProxyProvider) *Relay {
 	return &Relay{
-		Base:      outbound.NewBase(name, "", C.Relay, false),
+		Base:      outbound.NewBase(name, "", C.Relay, true),
 		single:    singledo.NewSingle(defaultGetProxiesDuration),
 		providers: providers,
 	}

--- a/adapters/outboundgroup/selector.go
+++ b/adapters/outboundgroup/selector.go
@@ -1,7 +1,6 @@
 package outboundgroup
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 
@@ -18,20 +17,8 @@ type Selector struct {
 	providers []provider.ProxyProvider
 }
 
-func (s *Selector) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := s.selected.DialContext(ctx, metadata)
-	if err == nil {
-		c.AppendToChains(s)
-	}
-	return c, err
-}
-
-func (s *Selector) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
-	pc, err := s.selected.DialUDP(metadata)
-	if err == nil {
-		pc.AppendToChains(s)
-	}
-	return pc, err
+func (s *Selector) Dialer(parent C.ProxyDialer) C.ProxyDialer {
+	return newGroupDialer(s, s.selected.Dialer(parent))
 }
 
 func (s *Selector) SupportUDP() bool {

--- a/adapters/outboundgroup/urltest.go
+++ b/adapters/outboundgroup/urltest.go
@@ -1,7 +1,6 @@
 package outboundgroup
 
 import (
-	"context"
 	"encoding/json"
 	"time"
 
@@ -22,20 +21,8 @@ func (u *URLTest) Now() string {
 	return u.fast().Name()
 }
 
-func (u *URLTest) DialContext(ctx context.Context, metadata *C.Metadata) (c C.Conn, err error) {
-	c, err = u.fast().DialContext(ctx, metadata)
-	if err == nil {
-		c.AppendToChains(u)
-	}
-	return c, err
-}
-
-func (u *URLTest) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
-	pc, err := u.fast().DialUDP(metadata)
-	if err == nil {
-		pc.AppendToChains(u)
-	}
-	return pc, err
+func (u *URLTest) Dialer(parent C.ProxyDialer) C.ProxyDialer {
+	return newGroupDialer(u, u.fast().Dialer(parent))
 }
 
 func (u *URLTest) proxies() []C.Proxy {

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -51,21 +51,17 @@ func (c Chain) String() string {
 
 type Conn interface {
 	net.Conn
-	Connection
 }
 
 type PacketConn interface {
 	net.PacketConn
-	Connection
 	WriteWithMetadata(p []byte, metadata *Metadata) (n int, err error)
 }
 
 type ProxyAdapter interface {
 	Name() string
 	Type() AdapterType
-	StreamConn(c net.Conn, metadata *Metadata) (net.Conn, error)
-	DialContext(ctx context.Context, metadata *Metadata) (Conn, error)
-	DialUDP(metadata *Metadata) (PacketConn, error)
+	Dialer(parent ProxyDialer) ProxyDialer
 	SupportUDP() bool
 	MarshalJSON() ([]byte, error)
 	Addr() string
@@ -80,9 +76,13 @@ type Proxy interface {
 	ProxyAdapter
 	Alive() bool
 	DelayHistory() []DelayHistory
-	Dial(metadata *Metadata) (Conn, error)
 	LastDelay() uint16
 	URLTest(ctx context.Context, url string) (uint16, error)
+}
+
+type ProxyDialer interface {
+	DialContext(ctx context.Context, metadata *Metadata) (Conn, Connection, error)
+	DialUDP(metadata *Metadata) (PacketConn, Connection, error)
 }
 
 // AdapterType is enum of adapter type

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -19,6 +19,7 @@ const (
 	HTTPCONNECT
 	SOCKS
 	REDIR
+	RELAY
 )
 
 type NetWork int

--- a/tunnel/tracker.go
+++ b/tunnel/tracker.go
@@ -54,7 +54,7 @@ func (tt *tcpTracker) Close() error {
 	return tt.Conn.Close()
 }
 
-func newTCPTracker(conn C.Conn, manager *Manager, metadata *C.Metadata, rule C.Rule) *tcpTracker {
+func newTCPTracker(conn C.Conn, connection C.Connection, manager *Manager, metadata *C.Metadata, rule C.Rule) *tcpTracker {
 	uuid, _ := uuid.NewV4()
 	ruleType := ""
 	if rule != nil {
@@ -68,7 +68,7 @@ func newTCPTracker(conn C.Conn, manager *Manager, metadata *C.Metadata, rule C.R
 			UUID:     uuid,
 			Start:    time.Now(),
 			Metadata: metadata,
-			Chain:    conn.Chains(),
+			Chain:    connection.Chains(),
 			Rule:     ruleType,
 		},
 	}
@@ -116,7 +116,7 @@ func (ut *udpTracker) Close() error {
 	return ut.PacketConn.Close()
 }
 
-func newUDPTracker(conn C.PacketConn, manager *Manager, metadata *C.Metadata, rule C.Rule) *udpTracker {
+func newUDPTracker(conn C.PacketConn, connection C.Connection, manager *Manager, metadata *C.Metadata, rule C.Rule) *udpTracker {
 	uuid, _ := uuid.NewV4()
 	ruleType := ""
 	if rule != nil {
@@ -130,7 +130,7 @@ func newUDPTracker(conn C.PacketConn, manager *Manager, metadata *C.Metadata, ru
 			UUID:     uuid,
 			Start:    time.Now(),
 			Metadata: metadata,
-			Chain:    conn.Chains(),
+			Chain:    connection.Chains(),
 			Rule:     ruleType,
 		},
 	}


### PR DESCRIPTION
使用嵌套 Dialer 替代 StreamConn/DialContext 嵌套

功能
- Relay 能够支持使用 UDP
- Relay 能够包含任何代理 (包括代理组 甚至是  另一个 Relay (
- ~~也许~~ 能对未来的 规则匹配缓存 有点用处


**仅仅完成简单 TCP/UDP 测试 还需要热心群众 ~~(小白鼠)~~ 测试其他东西**

