### PR TITLE
Fix: dns tcp-tls X509.HostnameError

### DIFF
--- a/dns/util.go
+++ b/dns/util.go
@@ -133,6 +133,7 @@ func transform(servers []NameServer, resolver *Resolver) []dnsClient {
 					ClientSessionCache: globalSessionCache,
 					// alpn identifier, see https://tools.ietf.org/html/draft-hoffman-dprive-dns-tls-alpn-00#page-6
 					NextProtos: []string{"dns"},
+					ServerName: host,
 				},
 				UDPSize: 4096,
 				Timeout: 5 * time.Second,


### PR DESCRIPTION
DoT with hostname instead of bare IP has never been working. This problem normally would be covered up when multiple DNS servers presented. If only one DoT DNS server with hostname, e.g. "tls://dns.rubyfish.cn:853", the log would show "All DNS requests failed". 

My config:
```yaml
dns:
  enhanced-mode: redir-host
  listen: 127.0.0.1:7874
  enable: true
  ipv6: false
  default-nameserver:
  - 114.114.114.114
  nameserver:
  - 114.114.114.114
  fallback:
  - tls://dns.rubyfish.cn:853
  fallback-filter:
    geoip: true
    ipcidr:
      - 240.0.0.0/4
      - 0.0.0.0/32
```

Adding the following debug logger to `dns/client.go`:
![image](https://user-images.githubusercontent.com/4312115/79527766-ff041d00-809a-11ea-941a-120b49793a34.png)

the root problem can be found when `dig @192.168.1.1 www.google.com` (my clash running in x86-64 router):
![image](https://user-images.githubusercontent.com/4312115/79527868-3b377d80-809b-11ea-8ef6-43e50a5308ff.png)

The problem is obvious, 'miekg/dns' has never been informed the hostname but only a resolved IP. After this patch applied:
![image](https://user-images.githubusercontent.com/4312115/79528078-a3865f00-809b-11ea-80e6-2d2894c01c31.png)

Edit:
I just found the `dev` branch has already been showing first DNS error, not in `master`. So the logger I added is not necessary to observe this problem
