### PR TITLE
[Feature] DNS: employ LruCache for optimistic DNS

### DIFF
--- a/common/cache/lrucache.go
+++ b/common/cache/lrucache.go
@@ -91,8 +91,8 @@ func (c *LruCache) Get(key interface{}) (interface{}, bool) {
 }
 
 // GetWithExpire returns the interface{} representation of a cached response,
-// a int64 give the expected expires timestamp in seconds
-// and  a bool set to true if the key was found.
+// a time.Time Give expected expires,
+// and a bool set to true if the key was found.
 // This method will NOT check the maxAge of element and will NOT update the expires.
 func (c *LruCache) GetWithExpire(key interface{}) (interface{}, time.Time, bool) {
 	entry := c.get(key)
@@ -122,6 +122,7 @@ func (c *LruCache) Set(key interface{}, value interface{}) {
 }
 
 // SetWithExpire stores the interface{} representation of a response for a given key and given exires.
+// The expires time will round to second.
 func (c *LruCache) SetWithExpire(key interface{}, value interface{}, expires time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/common/cache/lrucache_test.go
+++ b/common/cache/lrucache_test.go
@@ -136,3 +136,31 @@ func TestEvict(t *testing.T) {
 
 	assert.Equal(t, temp, 3)
 }
+
+func TestSetWithExpire(t *testing.T) {
+	c := NewLRUCache(WithAge(1))
+	now := time.Now().Unix()
+
+	tenSecBefore := time.Unix(now-10, 0)
+	c.SetWithExpire(1, 2, tenSecBefore)
+
+	// res is expected not to exist, and expires should be empty time.Time
+	res, expires, exist := c.GetWithExpire(1)
+	assert.Equal(t, nil, res)
+	assert.Equal(t, time.Time{}, expires)
+	assert.Equal(t, false, exist)
+
+}
+
+func TestStale(t *testing.T) {
+	c := NewLRUCache(WithAge(1), WithStale(true))
+	now := time.Now().Unix()
+
+	tenSecBefore := time.Unix(now-10, 0)
+	c.SetWithExpire(1, 2, tenSecBefore)
+
+	res, expires, exist := c.GetWithExpire(1)
+	assert.Equal(t, 2, res)
+	assert.Equal(t, tenSecBefore, expires)
+	assert.Equal(t, true, exist)
+}

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -109,7 +109,6 @@ func (r *Resolver) Exchange(m *D.Msg) (msg *D.Msg, err error) {
 		return
 	}
 	return r.exchangeWithoutCache(m)
-
 }
 
 // ExchangeWithoutCache a batch of dns request, and it do NOT GET from cache

--- a/dns/util.go
+++ b/dns/util.go
@@ -93,7 +93,7 @@ func putMsgToCache(c *cache.LruCache, key string, msg *D.Msg) {
 		return
 	}
 
-	c.SetWithExpire(key, msg.Copy(), time.Now().Unix()+int64(ttl))
+	c.SetWithExpire(key, msg.Copy(), time.Now().Add(time.Second*time.Duration(ttl)))
 }
 
 func setMsgTTL(msg *D.Msg, ttl uint32) {

--- a/dns/util.go
+++ b/dns/util.go
@@ -79,21 +79,21 @@ func (e EnhancedMode) String() string {
 	}
 }
 
-func putMsgToCache(c *cache.Cache, key string, msg *D.Msg) {
-	var ttl time.Duration
+func putMsgToCache(c *cache.LruCache, key string, msg *D.Msg) {
+	var ttl uint32
 	switch {
 	case len(msg.Answer) != 0:
-		ttl = time.Duration(msg.Answer[0].Header().Ttl) * time.Second
+		ttl = msg.Answer[0].Header().Ttl
 	case len(msg.Ns) != 0:
-		ttl = time.Duration(msg.Ns[0].Header().Ttl) * time.Second
+		ttl = msg.Ns[0].Header().Ttl
 	case len(msg.Extra) != 0:
-		ttl = time.Duration(msg.Extra[0].Header().Ttl) * time.Second
+		ttl = msg.Extra[0].Header().Ttl
 	default:
 		log.Debugln("[DNS] response msg error: %#v", msg)
 		return
 	}
 
-	c.Put(key, msg.Copy(), ttl)
+	c.SetWithExpire(key, msg.Copy(), time.Now().Unix()+int64(ttl))
 }
 
 func setMsgTTL(msg *D.Msg, ttl uint32) {


### PR DESCRIPTION
This PR replaces the existing DNS cache with LRU Cache and thus can achieve optimistic DNS.

### Changes:

When a DNS query comes to clash, if there is an expired msg in cache match the query, clash will return the expired msg and start to fetch the newer response from upstream **async**.

When mapping(redir-host/fake-ip) is enabled, when request without Host but IP comes to clash, clash will do IP-to-Host checking using this IP in LRU Cache. This procedure **will not** affect the TTL of the corresponding DNS messages.

### Discuss:

- What TTL should clash reply when an expired DNS msg return?
- How large should the cache capacity be set?
- Should cache size and optimistic DNS be configurable?