### PR TITLE
Fix: dns return success & recursion available if fake ip enabled

### DIFF
--- a/dns/middleware.go
+++ b/dns/middleware.go
@@ -21,13 +21,11 @@ func withFakeIP(fakePool *fakeip.Pool) middleware {
 				msg := &D.Msg{}
 				msg.Answer = []D.RR{}
 
-				setMsgTTL(msg, 1)
 				msg.SetRcode(r, D.RcodeSuccess)
 				msg.Authoritative = true
 				msg.RecursionAvailable = true
 
 				w.WriteMsg(msg)
-
 				return
 			} else if q.Qtype != D.TypeA {
 				next(w, r)
@@ -53,7 +51,6 @@ func withFakeIP(fakePool *fakeip.Pool) middleware {
 			msg.RecursionAvailable = true
 
 			w.WriteMsg(msg)
-
 			return
 		}
 	}

--- a/dns/middleware.go
+++ b/dns/middleware.go
@@ -18,7 +18,16 @@ func withFakeIP(fakePool *fakeip.Pool) middleware {
 			q := r.Question[0]
 
 			if q.Qtype == D.TypeAAAA {
-				D.HandleFailed(w, r)
+				msg := &D.Msg{}
+				msg.Answer = []D.RR{}
+
+				setMsgTTL(msg, 1)
+				msg.SetRcode(r, D.RcodeSuccess)
+				msg.Authoritative = true
+				msg.RecursionAvailable = true
+
+				w.WriteMsg(msg)
+
 				return
 			} else if q.Qtype != D.TypeA {
 				next(w, r)
@@ -39,9 +48,12 @@ func withFakeIP(fakePool *fakeip.Pool) middleware {
 			msg.Answer = []D.RR{rr}
 
 			setMsgTTL(msg, 1)
-			msg.SetRcode(r, msg.Rcode)
+			msg.SetRcode(r, D.RcodeSuccess)
 			msg.Authoritative = true
+			msg.RecursionAvailable = true
+
 			w.WriteMsg(msg)
+
 			return
 		}
 	}


### PR DESCRIPTION
修复 部分应用不使用 fake ip nameserver 的问题 (指 `nslookup`

这个 commit 前
```
kr328@2B ~ % nslookup www.baidu.com                                                            :(
;; Got recursion not available from 192.168.0.1, trying next server
Server:		fdb9:2d81:1d2f::1
Address:	fdb9:2d81:1d2f::1#53

Non-authoritative answer:
www.baidu.com	canonical name = www.a.shifen.com.
Name:	www.a.shifen.com
Address: 163.177.151.110
Name:	www.a.shifen.com
Address: 163.177.151.109
;; Got SERVFAIL reply from 192.168.0.1, trying next server

```

后
```
kr328@2B ~ % nslookup www.baidu.com
Server:		192.168.0.1
Address:	192.168.0.1#53

Name:	www.baidu.com
Address: 198.18.0.6
```

`nslookup` 版本
```
bind-tools 9.16.2-1
```