### PR TITLE
Fix: re-resolve dns on direct dial

### DIFF
--- a/adapters/outbound/direct.go
+++ b/adapters/outbound/direct.go
@@ -15,9 +15,6 @@ type Direct struct {
 
 func (d *Direct) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
 	address := net.JoinHostPort(metadata.Host, metadata.DstPort)
-	if metadata.DstIP != nil {
-		address = net.JoinHostPort(metadata.DstIP.String(), metadata.DstPort)
-	}
 
 	c, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {

--- a/adapters/outbound/direct.go
+++ b/adapters/outbound/direct.go
@@ -14,7 +14,7 @@ type Direct struct {
 }
 
 func (d *Direct) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	address := net.JoinHostPort(metadata.Host, metadata.DstPort)
+	address := net.JoinHostPort(metadata.String(), metadata.DstPort)
 
 	c, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {


### PR DESCRIPTION
按照目前的逻辑 一旦在规则匹配时 存在 DNS 解析行为 metadata.DstIP 必定不为空

在原先的逻辑下 DstIP 不为空时 会导致 双栈 Dial 逻辑失效

不过这样的改法可能会导致 最终 Dial 结果 与 规则匹配不一致 (