### PR TITLE
Fix: Valid dns answer

### DIFF
--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -174,7 +174,7 @@ func (r *Resolver) batchExchange(clients []dnsClient, m *D.Msg) (msg *D.Msg, err
 			m, err := r.ExchangeContext(ctx, m)
 			if err != nil {
 				return nil, err
-			} else if m.Rcode == D.RcodeServerFailure || m.Rcode == D.RcodeRefused {
+			} else if m.Rcode == D.RcodeServerFailure || m.Rcode == D.RcodeRefused || len(m.Answer) == 0 {
 				return nil, errors.New("server failure")
 			}
 			return m, nil


### PR DESCRIPTION
```
DEBU[0000] [DNS] response msg error: &dns.Msg{MsgHdr:dns.MsgHdr{Id:0xd403, Response:true, Opcode:0, Authoritative:false, Truncated:false, RecursionDesired:true, RecursionAvailable:true, Zero:false, AuthenticatedData:false, CheckingDisabled:false, Rcode:0}, Compress:false, Question:[]dns.Question{dns.Question{Name:"access-sngapm.qcloud.com.", Qtype:0x1c, Qclass:0x1}}, Answer:[]dns.RR(nil), Ns:[]dns.RR(nil), Extra:[]dns.RR(nil)}
```
