### PR TITLE
relay类型支持其它proxy group的高级特性

### DIFF
--- a/adapters/outbound/direct.go
+++ b/adapters/outbound/direct.go
@@ -16,7 +16,11 @@ type Direct struct {
 func (d *Direct) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
 	address := net.JoinHostPort(metadata.String(), metadata.DstPort)
 
-	c, err := dialer.DialContext(ctx, "tcp", address)
+	dialFunc := metadata.DialContext
+	if dialFunc == nil {
+		dialFunc = dialer.DialContext
+	}
+	c, err := dialFunc(ctx, "tcp", address)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/outbound/http.go
+++ b/adapters/outbound/http.go
@@ -51,7 +51,11 @@ func (h *Http) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (h *Http) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", h.addr)
+	dialFunc := metadata.DialContext
+	if dialFunc == nil {
+		dialFunc = dialer.DialContext
+	}
+	c, err := dialFunc(ctx, "tcp", h.addr)
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", h.addr, err)
 	}

--- a/adapters/outbound/shadowsocks.go
+++ b/adapters/outbound/shadowsocks.go
@@ -78,7 +78,11 @@ func (ss *ShadowSocks) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, e
 }
 
 func (ss *ShadowSocks) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", ss.addr)
+	dialFunc := metadata.DialContext
+	if dialFunc == nil {
+		dialFunc = dialer.DialContext
+	}
+	c, err := dialFunc(ctx, "tcp", ss.addr)
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", ss.addr, err)
 	}

--- a/adapters/outbound/snell.go
+++ b/adapters/outbound/snell.go
@@ -42,7 +42,11 @@ func (s *Snell) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (s *Snell) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", s.addr)
+	dialFunc := metadata.DialContext
+	if dialFunc == nil {
+		dialFunc = dialer.DialContext
+	}
+	c, err := dialFunc(ctx, "tcp", s.addr)
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", s.addr, err)
 	}

--- a/adapters/outbound/socks5.go
+++ b/adapters/outbound/socks5.go
@@ -59,7 +59,11 @@ func (ss *Socks5) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error)
 }
 
 func (ss *Socks5) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", ss.addr)
+	dialFunc := metadata.DialContext
+	if dialFunc == nil {
+		dialFunc = dialer.DialContext
+	}
+	c, err := dialFunc(ctx, "tcp", ss.addr)
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", ss.addr, err)
 	}

--- a/adapters/outbound/trojan.go
+++ b/adapters/outbound/trojan.go
@@ -39,7 +39,11 @@ func (t *Trojan) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) 
 }
 
 func (t *Trojan) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", t.addr)
+	dialFunc := metadata.DialContext
+	if dialFunc == nil {
+		dialFunc = dialer.DialContext
+	}
+	c, err := dialFunc(ctx, "tcp", t.addr)
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", t.addr, err)
 	}

--- a/adapters/outbound/vmess.go
+++ b/adapters/outbound/vmess.go
@@ -99,7 +99,11 @@ func (v *Vmess) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (v *Vmess) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", v.addr)
+	dialFunc := metadata.DialContext
+	if dialFunc == nil {
+		dialFunc = dialer.DialContext
+	}
+	c, err := dialFunc(ctx, "tcp", v.addr)
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error", v.addr)
 	}

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -1,6 +1,7 @@
 package constant
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"strconv"
@@ -65,6 +66,8 @@ type Metadata struct {
 	DstPort  string  `json:"destinationPort"`
 	AddrType int     `json:"-"`
 	Host     string  `json:"host"`
+
+	DialContext func(ctx context.Context, network, address string) (conn net.Conn, err error)
 }
 
 func (m *Metadata) RemoteAddress() string {


### PR DESCRIPTION
现在relay对proxy group的支持，仅限于将proxy group中的proxy给unwrap出来使用，丧失了fallback、url-test、select的高级特性能力。
这个PR简单修改了下，让relay使用其它proxy group时依然保留这些高级特性。