### PR TITLE
[Future] fallback to redir-host if host match fake-ip-filter

### DIFF
--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -121,7 +121,7 @@ func (r *Resolver) exchangeWithoutCache(m *D.Msg) (msg *D.Msg, err error) {
 		}
 
 		putMsgToCache(r.lruCache, q.String(), msg)
-		if r.mapping {
+		if r.mapping || r.fakeip {
 			ips := r.msgToIP(msg)
 			for _, ip := range ips {
 				putMsgToCache(r.lruCache, ip.String(), msg)
@@ -151,7 +151,10 @@ func (r *Resolver) exchangeWithoutCache(m *D.Msg) (msg *D.Msg, err error) {
 // IPToHost return fake-ip or redir-host mapping host
 func (r *Resolver) IPToHost(ip net.IP) (string, bool) {
 	if r.fakeip {
-		return r.pool.LookBack(ip)
+		record, existed := r.pool.LookBack(ip)
+		if existed {
+			return record, true
+		}
 	}
 
 	cache, _ := r.lruCache.Get(ip.String())


### PR DESCRIPTION
域名匹配到 fake-ip-filter 时 回滚到 redir-host 模式

能够让 域名规则 在 命中 fake-ip-filter 时 生效