### PR TITLE
Fix: cannot listen socks5 port on wsl

### DIFF
--- a/common/sockopt/reuseaddr_linux.go
+++ b/common/sockopt/reuseaddr_linux.go
@@ -2,6 +2,8 @@ package sockopt
 
 import (
 	"net"
+	"os/exec"
+	"strings"
 	"syscall"
 )
 
@@ -13,7 +15,24 @@ func UDPReuseaddr(c *net.UDPConn) (err error) {
 
 	rc.Control(func(fd uintptr) {
 		err = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+		if err != nil && IsWSL() == true {
+			err = nil
+		}
 	})
+
+	return
+}
+
+func IsWSL() (isWSL bool) {
+	cmd := exec.Command("uname", "-r")
+	kernelInfo, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+
+	if strings.Contains(string(kernelInfo), "Microsoft") {
+		return true
+	}
 
 	return
 }


### PR DESCRIPTION
针对 #713 的一个临时解决方案，该问题似乎是WSL的特殊性引起的，在微软修复之前，此临时方案可以对WSL进行单独处理，以保证能够正常使用。