### PR TITLE
[Fix] trie: should backtrack to parent if match fail

### DIFF
--- a/component/trie/domain.go
+++ b/component/trie/domain.go
@@ -96,45 +96,37 @@ func (t *DomainTrie) Search(domain string) *Node {
 		return nil
 	}
 
-	n := t.root
-	var dotWildcardNode *Node
-	var wildcardNode *Node
-	for i := len(parts) - 1; i >= 0; i-- {
-		part := parts[i]
-
-		if node := n.getChild(dotWildcard); node != nil {
-			dotWildcardNode = node
-		}
-
-		child := n.getChild(part)
-		if child == nil && wildcardNode != nil {
-			child = wildcardNode.getChild(part)
-		}
-		wildcardNode = n.getChild(wildcard)
-
-		n = child
-		if n == nil {
-			n = wildcardNode
-			wildcardNode = nil
-		}
-
-		if n == nil {
-			break
-		}
-	}
-
-	if n == nil {
-		if dotWildcardNode != nil {
-			return dotWildcardNode
-		}
-		return nil
-	}
+	n := t.search(t.root, parts)
 
 	if n.Data == nil {
 		return nil
 	}
 
 	return n
+}
+
+func (t *DomainTrie) search(node *Node, parts []string) *Node {
+	if len(parts) == 0 {
+		return node
+	}
+
+	if c := node.getChild(parts[len(parts)-1]); c != nil {
+		if n := t.search(c, parts[:len(parts)-1]); n != nil {
+			return n
+		}
+	}
+
+	if c := node.getChild(wildcard); c != nil {
+		if n := t.search(c, parts[:len(parts)-1]); n != nil {
+			return n
+		}
+	}
+
+	if c := node.getChild(dotWildcard); c != nil {
+		return c
+	}
+
+	return nil
 }
 
 // New returns a new, empty Trie.

--- a/component/trie/domain_test.go
+++ b/component/trie/domain_test.go
@@ -39,6 +39,10 @@ func TestTrie_Wildcard(t *testing.T) {
 		".example.net",
 		".apple.*",
 		"+.foo.com",
+		"+.stun.*.*",
+		"+.stun.*.*.*",
+		"+.stun.*.*.*.*",
+		"stun.l.google.com",
 	}
 
 	for _, domain := range domains {
@@ -52,6 +56,7 @@ func TestTrie_Wildcard(t *testing.T) {
 	assert.NotNil(t, tree.Search("test.apple.com"))
 	assert.NotNil(t, tree.Search("test.foo.com"))
 	assert.NotNil(t, tree.Search("foo.com"))
+	assert.NotNil(t, tree.Search("global.stun.website.com"))
 	assert.Nil(t, tree.Search("foo.sub.example.com"))
 	assert.Nil(t, tree.Search("foo.example.dev"))
 	assert.Nil(t, tree.Search("example.com"))


### PR DESCRIPTION
假设 trie 已插入以下域名

```
"+.stun.*.*"
"+.stun.*.*.*"
"+.stun.*.*.*.*"
"lens.l.google.com"
"stun.l.google.com"
"*.n.n.srv.nintendo.net"
```

在旧逻辑上 匹配域名 `global.stun.website.com` 时

会因为 com 进入 `lens.l.google.com/stun.l.google.com` 的节点 接下来在 和 `google` 匹配时失败 返回 nil