### PR TITLE
fix dns fallback

### DIFF
--- a/dns/filters.go
+++ b/dns/filters.go
@@ -14,7 +14,7 @@ type geoipFilter struct{}
 
 func (gf *geoipFilter) Match(ip net.IP) bool {
 	record, _ := mmdb.Instance().Country(ip)
-	return record.Country.IsoCode != "CN" && record.Country.IsoCode != ""
+	return record.Country.IsoCode != "CN"
 }
 
 type ipnetFilter struct {


### PR DESCRIPTION
```
❯ dig raw.githubusercontent.com @192.168.1.1

; <<>> DiG 9.10.6 <<>> raw.githubusercontent.com @192.168.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12862
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;raw.githubusercontent.com.	IN	A

;; ANSWER SECTION:
raw.githubusercontent.com. 3600	IN	A	0.0.0.0

;; Query time: 11 msec
;; SERVER: 192.168.1.1#53(192.168.1.1)
;; WHEN: Wed Jun 24 12:58:58 HKT 2020
;; MSG SIZE  rcvd: 70
```

`0.0.0.0` shoud match. 