### PR TITLE
Improve: add `full-match' parameter to PROCESS-NAME

### DIFF
--- a/rules/base.go
+++ b/rules/base.go
@@ -11,11 +11,21 @@ var (
 	ErrInvalidNetwork     = errors.New("invalid network")
 
 	noResolve = "no-resolve"
+	fullMatch = "full-match"
 )
 
 func HasNoResolve(params []string) bool {
 	for _, p := range params {
 		if p == noResolve {
+			return true
+		}
+	}
+	return false
+}
+
+func HasFullMatch(params []string) bool {
+	for _, p := range params {
+		if p == fullMatch {
 			return true
 		}
 	}

--- a/rules/parser.go
+++ b/rules/parser.go
@@ -32,7 +32,8 @@ func ParseRule(tp, payload, target string, params []string) (C.Rule, error) {
 	case "DST-PORT":
 		parsed, parseErr = NewPort(payload, target, false)
 	case "PROCESS-NAME":
-		parsed, parseErr = NewProcess(payload, target)
+		fullMatch := HasFullMatch(params)
+		parsed, parseErr = NewProcess(payload, target, fullMatch)
 	case "MATCH":
 		parsed = NewMatch(target)
 	default:

--- a/rules/process.go
+++ b/rules/process.go
@@ -1,0 +1,37 @@
+package rules
+
+import (
+	"unsafe"
+
+	"github.com/Dreamacro/clash/common/cache"
+	C "github.com/Dreamacro/clash/constant"
+)
+
+// store process name for when dealing with multiple PROCESS-NAME rules
+var processCache = cache.NewLRUCache(cache.WithAge(2), cache.WithSize(64))
+
+type Process struct {
+	adapter   string
+	process   string
+	fullMatch bool
+}
+
+func (p *Process) RuleType() C.RuleType {
+	return C.Process
+}
+
+func (p *Process) Adapter() string {
+	return p.adapter
+}
+
+func (p *Process) Payload() string {
+	return p.process
+}
+
+func (p *Process) ShouldResolveIP() bool {
+	return false
+}
+
+func readNativeUint32(b []byte) uint32 {
+	return *(*uint32)(unsafe.Pointer(&b[0]))
+}

--- a/rules/process_darwin.go
+++ b/rules/process_darwin.go
@@ -12,24 +12,11 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/Dreamacro/clash/common/cache"
 	C "github.com/Dreamacro/clash/constant"
 	"github.com/Dreamacro/clash/log"
 )
 
-// store process name for when dealing with multiple PROCESS-NAME rules
-var processCache = cache.NewLRUCache(cache.WithAge(2), cache.WithSize(64))
-
-type Process struct {
-	adapter string
-	process string
-}
-
-func (ps *Process) RuleType() C.RuleType {
-	return C.Process
-}
-
-func (ps *Process) Match(metadata *C.Metadata) bool {
+func (p *Process) Match(metadata *C.Metadata) bool {
 	key := fmt.Sprintf("%s:%s:%s", metadata.NetWork.String(), metadata.SrcIP.String(), metadata.SrcPort)
 	cached, hit := processCache.Get(key)
 	if !hit {
@@ -44,25 +31,23 @@ func (ps *Process) Match(metadata *C.Metadata) bool {
 		cached = name
 	}
 
-	return strings.EqualFold(cached.(string), ps.process)
+	name := cached.(string)
+	if !p.fullMatch {
+		name = filepath.Base(name)
+	}
+
+	return strings.EqualFold(name, p.process)
 }
 
-func (p *Process) Adapter() string {
-	return p.adapter
-}
+func NewProcess(process string, adapter string, fullMatch bool) (*Process, error) {
+	if !fullMatch {
+		process = filepath.Base(process)
+	}
 
-func (p *Process) Payload() string {
-	return p.process
-}
-
-func (p *Process) ShouldResolveIP() bool {
-	return false
-}
-
-func NewProcess(process string, adapter string) (*Process, error) {
 	return &Process{
-		adapter: adapter,
-		process: process,
+		adapter:   adapter,
+		process:   process,
+		fullMatch: fullMatch,
 	}, nil
 }
 
@@ -90,7 +75,7 @@ func getExecPathFromPID(pid uint32) (string, error) {
 		return "", nil
 	}
 
-	return filepath.Base(string(buf[:firstZero])), nil
+	return string(buf[:firstZero]), nil
 }
 
 func getExecPathFromAddress(metadata *C.Metadata) (string, error) {
@@ -163,8 +148,4 @@ func getExecPathFromAddress(metadata *C.Metadata) (string, error) {
 	}
 
 	return "", errors.New("process not found")
-}
-
-func readNativeUint32(b []byte) uint32 {
-	return *(*uint32)(unsafe.Pointer(&b[0]))
 }

--- a/rules/process_linux.go
+++ b/rules/process_linux.go
@@ -244,17 +244,30 @@ func resolveProcessNameByProcSearch(inode, uid int) (string, error) {
 			}
 
 			if bytes.Compare(buffer[:n], socket) == 0 {
-				n, err := syscall.Readlink(path.Join(processPath, "exe"), buffer)
+				cmdline, err := ioutil.ReadFile(path.Join(processPath, "cmdline"))
 				if err != nil {
 					return "", err
 				}
 
-				return string(buffer[:n]), nil
+				return splitCmdline(cmdline), nil
 			}
 		}
 	}
 
 	return "", syscall.ESRCH
+}
+
+func splitCmdline(cmdline []byte) string {
+	indexOfEndOfString := len(cmdline)
+
+	for i, c := range cmdline {
+		if c == 0 {
+			indexOfEndOfString = i
+			break
+		}
+	}
+
+	return string(cmdline[:indexOfEndOfString])
 }
 
 func isPid(s string) bool {

--- a/rules/process_other.go
+++ b/rules/process_other.go
@@ -7,6 +7,6 @@ import (
 	C "github.com/Dreamacro/clash/constant"
 )
 
-func NewProcess(process string, adapter string) (C.Rule, error) {
+func NewProcess(process string, adapter string, fullMatch bool) (C.Rule, error) {
 	return nil, ErrPlatformNotSupport
 }


### PR DESCRIPTION
This PR enables PROCESS-NAME to match the absolute path of a process executable, which will be of help to distinguish between different paths with same base names.

Example:
```yaml
rules:
- PROCESS-NAME,/usr/local/bin/url,DIRECT,full-match
- PROCESS-NAME,/usr/bin/curl,REJECT,full-match
- PROCESS-NAME,C:\Users\admin\Desktop\curl\bin\curl.exe,DIRECT,full-match
- PROCESS-NAME,curl,DIRECT
- PROCESS-NAME,/usr/bin/curl,DIRECT # same as above line, the process is reset to its base name if full-match omits
```

For consistency among all supported platforms, I changed the behavior on linux from `read(/proc/${PID}/cmdline)[0]` to `readlink(/proc/${PID}/exe)`. Please let me know if there are any side effects. @Kr328 Thanks!

MISC: The common parts are moved to `rules/process.go`.