### PR TITLE
Try fix crash

### DIFF
--- a/component/ssr/protocol/auth_aes128_md5.go
+++ b/component/ssr/protocol/auth_aes128_md5.go
@@ -105,6 +105,9 @@ func (a *authAES128) Decode(b []byte) ([]byte, int, error) {
 			pos = int(binary.LittleEndian.Uint16(b[5:7])) + 4
 		}
 
+		if pos > length-4 {
+			return nil, 0, errAuthAES128PositionTooLarge
+		}
 		a.buffer.Write(b[pos : length-4])
 		b = b[length:]
 		bSize -= length

--- a/component/ssr/protocol/auth_aes128_md5.go
+++ b/component/ssr/protocol/auth_aes128_md5.go
@@ -81,8 +81,9 @@ func (a *authAES128) Decode(b []byte) ([]byte, int, error) {
 
 		h := a.hmac(key, b[:2])
 		if !bytes.Equal(h[:2], b[2:4]) {
-			return nil, 0, errAuthAES128HMACError
+			return nil, 0, errAuthAES128IncorrectMAC
 		}
+
 		length := int(binary.LittleEndian.Uint16(b[:2]))
 		if length >= 8192 || length < 8 {
 			return nil, 0, errAuthAES128DataLengthError
@@ -90,6 +91,12 @@ func (a *authAES128) Decode(b []byte) ([]byte, int, error) {
 		if length > bSize {
 			break
 		}
+
+		h = a.hmac(key, b[:bSize-4])
+		if !bytes.Equal(h[:4], b[bSize-4:]) {
+			return nil, 0, errAuthAES128IncorrectChecksum
+		}
+
 		a.recvID++
 		pos := int(b[4])
 		if pos < 255 {
@@ -144,7 +151,7 @@ func (a *authAES128) DecodePacket(b []byte) ([]byte, int, error) {
 	bSize := len(b)
 	h := a.hmac(a.Key, b[:bSize-4])
 	if !bytes.Equal(h[:4], b[bSize-4:]) {
-		return nil, 0, errAuthAES128HMACError
+		return nil, 0, errAuthAES128IncorrectMAC
 	}
 	return b[:bSize-4], bSize - 4, nil
 }

--- a/component/ssr/protocol/protocol.go
+++ b/component/ssr/protocol/protocol.go
@@ -12,6 +12,7 @@ var (
 	errAuthAES128IncorrectMAC      = errors.New("auth_aes128_* post decrypt incorrect mac")
 	errAuthAES128DataLengthError   = errors.New("auth_aes128_* post decrypt length mismatch")
 	errAuthAES128IncorrectChecksum = errors.New("auth_aes128_* post decrypt incorrect checksum")
+	errAuthAES128PositionTooLarge  = errors.New("auth_aes128_* post decrypt posision is too large")
 	errAuthSHA1v4CRC32Error        = errors.New("auth_sha1_v4 post decrypt data crc32 error")
 	errAuthSHA1v4DataLengthError   = errors.New("auth_sha1_v4 post decrypt data length error")
 	errAuthSHA1v4IncorrectChecksum = errors.New("auth_sha1_v4 post decrypt incorrect checksum")

--- a/component/ssr/protocol/protocol.go
+++ b/component/ssr/protocol/protocol.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	errAuthAES128HMACError         = errors.New("auth_aes128_* post decrypt hmac error")
+	errAuthAES128IncorrectMAC      = errors.New("auth_aes128_* post decrypt incorrect mac")
 	errAuthAES128DataLengthError   = errors.New("auth_aes128_* post decrypt length mismatch")
+	errAuthAES128IncorrectChecksum = errors.New("auth_aes128_* post decrypt incorrect checksum")
 	errAuthSHA1v4CRC32Error        = errors.New("auth_sha1_v4 post decrypt data crc32 error")
 	errAuthSHA1v4DataLengthError   = errors.New("auth_sha1_v4 post decrypt data length error")
 	errAuthSHA1v4IncorrectChecksum = errors.New("auth_sha1_v4 post decrypt incorrect checksum")


### PR DESCRIPTION
尝试修复#879 

无法复现该问题。翻看了一下libev，遗漏了对checksum的校验([`91f4d7c`](https://github.com/Dreamacro/clash/commit/91f4d7c66ea672fa0ce1540951feefb44b38295b),但无法确定是否是由于这个造成的)；对`pos`和`length - 4`的大小进行了一个判断([`5f9a69f`](https://github.com/Dreamacro/clash/commit/5f9a69fdc8947abde157717ea923a5277d1a9c9d),libev中没有该部分代码)，避免出现crash，如果觉得没必要可以不合并这个commit。