### PR TITLE
Fix: use the wrong variable

### DIFF
--- a/component/ssr/protocol/auth_aes128_md5.go
+++ b/component/ssr/protocol/auth_aes128_md5.go
@@ -92,8 +92,8 @@ func (a *authAES128) Decode(b []byte) ([]byte, int, error) {
 			break
 		}
 
-		h = a.hmac(key, b[:bSize-4])
-		if !bytes.Equal(h[:4], b[bSize-4:]) {
+		h = a.hmac(key, b[:length-4])
+		if !bytes.Equal(h[:4], b[length-4:length]) {
 			return nil, 0, errAuthAES128IncorrectChecksum
 		}
 


### PR DESCRIPTION
Fix #894 

抱歉，写 #882 的时候可能脑子不太清醒，用错了变量。

麻烦check一下[python源码](https://github.com/shadowsocksr-backup/shadowsocksr/blob/manyuser/shadowsocks/obfsplugin/auth.py#L611,L614)和[libev源码](https://github.com/shadowsocksr-backup/shadowsocksr-libev/blob/master/src/obfs/auth.c#L894,L903)，避免再次出错。