### PR TITLE
VMess HTTP/2 transport support

### DIFF
--- a/adapters/outbound/vmess.go
+++ b/adapters/outbound/vmess.go
@@ -125,7 +125,7 @@ func (v *Vmess) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 			Path:  v.option.HTTP2Opts.Path,
 		}
 
-		c = vmess.StreamH2Conn(c, h2Opts)
+		c, err = vmess.StreamH2Conn(c, h2Opts)
 	default:
 		// handle TLS
 		if v.option.TLS {

--- a/adapters/outbound/vmess.go
+++ b/adapters/outbound/vmess.go
@@ -119,6 +119,9 @@ func (v *Vmess) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 		}
 
 		c, err = vmess.StreamTLSConn(c, &tlsOpts)
+		if err != nil {
+			return nil, err
+		}
 
 		h2Opts := &vmess.H2Config{
 			Hosts: v.option.HTTP2Opts.Host,
@@ -198,7 +201,7 @@ func NewVmess(option VmessOption) (*Vmess, error) {
 	if err != nil {
 		return nil, err
 	}
-	if option.Network == "h2" && option.TLS == false {
+	if option.Network == "h2" && !option.TLS {
 		return nil, fmt.Errorf("TLS must be true with h2 network")
 	}
 

--- a/adapters/outbound/vmess.go
+++ b/adapters/outbound/vmess.go
@@ -198,6 +198,9 @@ func NewVmess(option VmessOption) (*Vmess, error) {
 	if err != nil {
 		return nil, err
 	}
+	if option.Network == "h2" && option.TLS == false {
+		return nil, fmt.Errorf("TLS must be true with h2 network")
+	}
 
 	return &Vmess{
 		Base: &Base{

--- a/adapters/outbound/vmess.go
+++ b/adapters/outbound/vmess.go
@@ -106,23 +106,24 @@ func (v *Vmess) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 
 		c = vmess.StreamHTTPConn(c, httpOpts)
 	case "h2":
-		h2Opts := &vmess.H2Config{
-			Hosts: v.option.HTTP2Opts.Host,
-			Path:  v.option.HTTP2Opts.Path,
-		}
-
 		host, _, _ := net.SplitHostPort(v.addr)
-		tlsOpts := &vmess.TLSConfig{
+		tlsOpts := vmess.TLSConfig{
 			Host:           host,
 			SkipCertVerify: v.option.SkipCertVerify,
 			SessionCache:   getClientSessionCache(),
+			NextProtos:     []string{"h2"},
 		}
 
 		if v.option.ServerName != "" {
 			tlsOpts.Host = v.option.ServerName
 		}
 
-		c, err = vmess.StreamTLSConn(c, tlsOpts)
+		c, err = vmess.StreamTLSConn(c, &tlsOpts)
+
+		h2Opts := &vmess.H2Config{
+			Hosts: v.option.HTTP2Opts.Host,
+			Path:  v.option.HTTP2Opts.Path,
+		}
 
 		c = vmess.StreamH2Conn(c, h2Opts)
 	default:

--- a/component/vmess/h2.go
+++ b/component/vmess/h2.go
@@ -59,7 +59,7 @@ func (hc *h2Conn) establishConn() error {
 
 // Read implements net.Conn.Read()
 func (hc *h2Conn) Read(b []byte) (int, error) {
-	if hc.res != nil && hc.res.Close == false {
+	if hc.res != nil && !hc.res.Close {
 		n, err := hc.res.Body.Read(b)
 		return n, err
 	}

--- a/component/vmess/h2.go
+++ b/component/vmess/h2.go
@@ -1,0 +1,117 @@
+package vmess
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/http2"
+)
+
+type h2Conn struct {
+	net.Conn
+	req     *http.Request
+	pwriter *io.PipeWriter
+	res     *http.Response
+	cfg     *H2Config
+}
+
+type H2Config struct {
+	Hosts []string
+	Path  string
+}
+
+func (hc *h2Conn) establishConn() error {
+	// TODO: use underlaying conn
+	client := &http.Client{}
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		return err
+	}
+	tlsConfig := &tls.Config{
+		RootCAs: caCertPool,
+	}
+
+	client.Transport = &http2.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	preader, pwriter := io.Pipe()
+
+	host := hc.cfg.Hosts[rand.Intn(len(hc.cfg.Hosts))]
+	path := hc.cfg.Path
+	// TODO: connect use VMess Host instead of H2 Host
+	req := http.Request{
+		Method: "PUT",
+		Host:   host,
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   host,
+			Path:   path,
+		},
+		Proto:      "HTTP/2",
+		ProtoMajor: 2,
+		ProtoMinor: 0,
+		Body:       preader,
+		Header: map[string][]string{
+			"Accept-Encoding": {"identity"},
+		},
+	}
+
+	res, err := client.Do(&req)
+	if err != nil {
+		return err
+	}
+
+	hc.req = &req
+	hc.res = res
+	hc.pwriter = pwriter
+
+	return nil
+}
+
+// Read implements net.Conn.Read()
+func (hc *h2Conn) Read(b []byte) (int, error) {
+	if hc.res != nil && hc.res.Close == false {
+		n, err := hc.res.Body.Read(b)
+		return n, err
+	}
+
+	if err := hc.establishConn(); err != nil {
+		return 0, err
+	}
+	return hc.res.Body.Read(b)
+}
+
+// Write implements io.Writer.
+func (hc *h2Conn) Write(b []byte) (int, error) {
+	if hc.req != nil && hc.pwriter != nil && hc.res != nil && hc.res.Close == false {
+		return hc.pwriter.Write(b)
+	}
+
+	if err := hc.establishConn(); err != nil {
+		return 0, err
+	}
+	return hc.pwriter.Write(b)
+}
+
+func (hc *h2Conn) Close() error {
+	if err := hc.pwriter.Close(); err != nil {
+		return err
+	}
+	if err := hc.req.Body.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func StreamH2Conn(conn net.Conn, cfg *H2Config) net.Conn {
+	return &h2Conn{
+		Conn: conn,
+		cfg:  cfg,
+	}
+}

--- a/component/vmess/h2.go
+++ b/component/vmess/h2.go
@@ -95,17 +95,17 @@ func (hc *h2Conn) Close() error {
 	return nil
 }
 
-func StreamH2Conn(conn net.Conn, cfg *H2Config) net.Conn {
+func StreamH2Conn(conn net.Conn, cfg *H2Config) (net.Conn, error) {
 	transport := &http2.Transport{}
 
 	cconn, err := transport.NewClientConn(conn)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return &h2Conn{
 		Conn:       conn,
 		ClientConn: cconn,
 		cfg:        cfg,
-	}
+	}, nil
 }

--- a/component/vmess/tls.go
+++ b/component/vmess/tls.go
@@ -9,6 +9,7 @@ type TLSConfig struct {
 	Host           string
 	SkipCertVerify bool
 	SessionCache   tls.ClientSessionCache
+	NextProtos     []string
 }
 
 func StreamTLSConn(conn net.Conn, cfg *TLSConfig) (net.Conn, error) {
@@ -16,6 +17,7 @@ func StreamTLSConn(conn net.Conn, cfg *TLSConfig) (net.Conn, error) {
 		ServerName:         cfg.Host,
 		InsecureSkipVerify: cfg.SkipCertVerify,
 		ClientSessionCache: cfg.SessionCache,
+		NextProtos:         cfg.NextProtos,
 	}
 
 	tlsConn := tls.Client(conn, tlsConfig)

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ golang.org/x/sys v0.0.0-20191224085550-c709ea063b76/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed h1:J22ig1FUekjjkmZUM7pTKixYm8DvrYsvrBZdunYeIuQ=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
# Feature

Support HTTP/2 transport for VMess.

```yaml
proxies:
  - name: Proxy
    type: vmess
    server: 1.14.5.14
    port: 443
    uuid: 433a65e8-6ab0-49cb-98b6-bde1605f000a
    alterId: 15
    cipher: auto
    network: h2
    h2-opts:
      host:
        - http.example.com
        - http-alt.example.com
      path: /
    tls: true
```

## Implement Details

The client will reuse existing TLS connection by `StreamTLSConn` (while setting ALPN to be `h2`), send HTTP/2 requests, and perform Read/Write on the connection created. It will randomly choose a host for HTTP/2 `:authority` header from `h2-opts.host`.

# TODOs

- [x] connect to remote host with `server` instead of using `h2-opts.host`
- [x] constraint `tls` must be `true`
- [x] respect existing `tls` settings (Q: what is the `net.Conn` passed to the very first `StreamConn` call? If this question answered, the implement can be enhanced.)