### PR TITLE
引入对 dial error timeout 等情况的惩罚

### DIFF
--- a/adapters/outbound/base.go
+++ b/adapters/outbound/base.go
@@ -129,6 +129,10 @@ func (p *Proxy) DelayHistory() []C.DelayHistory {
 	return histories
 }
 
+func (p *Proxy) SetNotAlive() {
+	atomic.StoreUint32(&p.alive, 0)
+}
+
 // LastDelay return last history record. if proxy is not alive, return the max value of uint16.
 func (p *Proxy) LastDelay() (delay uint16) {
 	var max uint16 = 0xffff

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -86,6 +86,7 @@ type Proxy interface {
 	DelayHistory() []DelayHistory
 	Dial(metadata *Metadata) (Conn, error)
 	LastDelay() uint16
+	SetNotAlive()
 	URLTest(ctx context.Context, url string) (uint16, error)
 }
 

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -263,6 +263,7 @@ func handleTCPConn(localConn C.ServerAdapter) {
 
 	remoteConn, err := proxy.Dial(metadata)
 	if err != nil {
+		proxy.SetNotAlive()
 		log.Warnln("dial %s error: %s", proxy.Name(), err.Error())
 		return
 	}


### PR DESCRIPTION
问题点：
在 healthcheck 的时间间隔内，如果代理发生问题，不会马上切换为别的代理，clash 依然会使用当前策略下的最优代理，直到下一次 healthcheck 此代理被判断非 alive

一个解决方案：
引入惩罚机制，在 dial error 时马上设置代理为非 alive，下一次请求就会切换节点

一个简单的想法，不清楚是否有更好方案，欢迎讨论