### PR TITLE
Fix: potential PCB buffer overflow on bsd systems

### DIFF
--- a/rules/process_darwin.go
+++ b/rules/process_darwin.go
@@ -127,8 +127,8 @@ func getExecPathFromAddress(metadata *C.Metadata) (string, error) {
 		// rup8(sizeof(xtcpcb_n))
 		itemSize += 208
 	}
-	// skip the first and last xinpgen(24 bytes) block
-	for i := 24; i < len(buf)-24; i += itemSize {
+	// skip the first xinpgen(24 bytes) block
+	for i := 24; i+itemSize <= len(buf); i += itemSize {
 		// offset of xinpcb_n and xsocket_n
 		inp, so := i, i+104
 

--- a/rules/process_freebsd_amd64.go
+++ b/rules/process_freebsd_amd64.go
@@ -95,7 +95,7 @@ func searchSocketPid(socket uint64) (uint32, error) {
 
 	// struct xfile
 	itemSize := 128
-	for i := 0; i < len(buf); i += itemSize {
+	for i := 0; i+itemSize <= len(buf); i += itemSize {
 		// xfile.xf_data
 		data := binary.BigEndian.Uint64(buf[i+56 : i+64])
 		if data == socket {
@@ -141,8 +141,8 @@ func getExecPathFromAddress(metadata *C.Metadata) (string, error) {
 
 	buf := []byte(value)
 
-	// skip the first and last xinpgen(64 bytes) block
-	for i := 64; i < len(buf)-64; i += itemSize {
+	// skip the first xinpgen(64 bytes) block
+	for i := 64; i+itemSize <= len(buf); i += itemSize {
 		inp := i + inpOffset
 
 		srcPort := binary.BigEndian.Uint16(buf[inp+254 : inp+256])


### PR DESCRIPTION
This PR aims to fix https://github.com/Dreamacro/clash/issues/879#issuecomment-685732139

By https://github.com/golang/go/blob/master/src/syscall/syscall_bsd.go#L473, the result of `sysctl` will be trimmed.
