### PR TITLE
Feature: Adds Plain TCP Redirect Outbound

### DIFF
--- a/adapters/outbound/base.go
+++ b/adapters/outbound/base.go
@@ -18,10 +18,11 @@ var (
 )
 
 type Base struct {
-	name string
-	addr string
-	tp   C.AdapterType
-	udp  bool
+	name       string
+	addr       string
+	tp         C.AdapterType
+	udp        bool
+	socketmark string
 }
 
 func (b *Base) Name() string {
@@ -44,6 +45,9 @@ func (b *Base) SupportUDP() bool {
 	return b.udp
 }
 
+func (b *Base) SocketMark() string {
+	return b.socketmark
+}
 func (b *Base) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{
 		"type": b.Type().String(),
@@ -59,7 +63,7 @@ func (b *Base) Unwrap(metadata *C.Metadata) C.Proxy {
 }
 
 func NewBase(name string, addr string, tp C.AdapterType, udp bool) *Base {
-	return &Base{name, addr, tp, udp}
+	return &Base{name, addr, tp, udp, ""}
 }
 
 type conn struct {

--- a/adapters/outbound/base.go
+++ b/adapters/outbound/base.go
@@ -23,6 +23,7 @@ type Base struct {
 	tp         C.AdapterType
 	udp        bool
 	socketmark string
+	ifname     string
 }
 
 func (b *Base) Name() string {
@@ -48,6 +49,11 @@ func (b *Base) SupportUDP() bool {
 func (b *Base) SocketMark() string {
 	return b.socketmark
 }
+
+func (b *Base) Interface() string {
+	return b.ifname
+}
+
 func (b *Base) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{
 		"type": b.Type().String(),
@@ -63,7 +69,7 @@ func (b *Base) Unwrap(metadata *C.Metadata) C.Proxy {
 }
 
 func NewBase(name string, addr string, tp C.AdapterType, udp bool) *Base {
-	return &Base{name, addr, tp, udp, ""}
+	return &Base{name, addr, tp, udp, "", ""}
 }
 
 type conn struct {

--- a/adapters/outbound/direct.go
+++ b/adapters/outbound/direct.go
@@ -15,12 +15,13 @@ type Direct struct {
 type DirectOption struct {
 	Name       string `proxy:"name"`
 	SocketMark string `proxy:"socket-mark,omitempty"`
+	Interface  string `proxy:"interface-name,omitempty"`
 }
 
 func (d *Direct) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
 	address := net.JoinHostPort(metadata.String(), metadata.DstPort)
 
-	c, err := dialer.DialContext(ctx, "tcp", address, d.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", address, dialer.DialOptions{SocketMark: d.SocketMark(), Interface: d.Interface()})
 	if err != nil {
 		return nil, err
 	}
@@ -47,23 +48,17 @@ func NewDirectWithOption(option DirectOption) *Direct {
 			tp:         C.Direct,
 			udp:        true,
 			socketmark: option.SocketMark,
+			ifname:     option.Interface,
 		},
 	}
 }
 
-func NewDirect(socketMark ...string) *Direct {
-
-	sm := ""
-	if socketMark != nil {
-		sm = socketMark[0]
-	}
-
+func NewDirect() *Direct {
 	return &Direct{
 		Base: &Base{
-			name:       "DIRECT",
-			tp:         C.Direct,
-			udp:        true,
-			socketmark: sm,
+			name: "DIRECT",
+			tp:   C.Direct,
+			udp:  true,
 		},
 	}
 }

--- a/adapters/outbound/direct.go
+++ b/adapters/outbound/direct.go
@@ -12,10 +12,15 @@ type Direct struct {
 	*Base
 }
 
+type DirectOption struct {
+	Name       string `proxy:"name"`
+	SocketMark string `proxy:"socket-mark,omitempty"`
+}
+
 func (d *Direct) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
 	address := net.JoinHostPort(metadata.String(), metadata.DstPort)
 
-	c, err := dialer.DialContext(ctx, "tcp", address)
+	c, err := dialer.DialContext(ctx, "tcp", address, d.SocketMark())
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +40,30 @@ type directPacketConn struct {
 	net.PacketConn
 }
 
-func NewDirect() *Direct {
+func NewDirectWithOption(option DirectOption) *Direct {
 	return &Direct{
 		Base: &Base{
-			name: "DIRECT",
-			tp:   C.Direct,
-			udp:  true,
+			name:       option.Name,
+			tp:         C.Direct,
+			udp:        true,
+			socketmark: option.SocketMark,
+		},
+	}
+}
+
+func NewDirect(socketMark ...string) *Direct {
+
+	sm := ""
+	if socketMark != nil {
+		sm = socketMark[0]
+	}
+
+	return &Direct{
+		Base: &Base{
+			name:       "DIRECT",
+			tp:         C.Direct,
+			udp:        true,
+			socketmark: sm,
 		},
 	}
 }

--- a/adapters/outbound/http.go
+++ b/adapters/outbound/http.go
@@ -33,6 +33,7 @@ type HttpOption struct {
 	TLS            bool   `proxy:"tls,omitempty"`
 	SkipCertVerify bool   `proxy:"skip-cert-verify,omitempty"`
 	SocketMark     string `proxy:"socket-mark,omitempty"`
+	Interface      string `proxy:"interface-name,omitempty"`
 }
 
 func (h *Http) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
@@ -52,7 +53,7 @@ func (h *Http) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (h *Http) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", h.addr, h.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", h.addr, dialer.DialOptions{SocketMark: h.SocketMark(), Interface: h.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", h.addr, err)
 	}
@@ -128,6 +129,7 @@ func NewHttp(option HttpOption) *Http {
 			addr:       net.JoinHostPort(option.Server, strconv.Itoa(option.Port)),
 			tp:         C.Http,
 			socketmark: option.SocketMark,
+			ifname:     option.Interface,
 		},
 		user:      option.UserName,
 		pass:      option.Password,

--- a/adapters/outbound/http.go
+++ b/adapters/outbound/http.go
@@ -32,6 +32,7 @@ type HttpOption struct {
 	Password       string `proxy:"password,omitempty"`
 	TLS            bool   `proxy:"tls,omitempty"`
 	SkipCertVerify bool   `proxy:"skip-cert-verify,omitempty"`
+	SocketMark     string `proxy:"socket-mark,omitempty"`
 }
 
 func (h *Http) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
@@ -51,7 +52,7 @@ func (h *Http) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (h *Http) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", h.addr)
+	c, err := dialer.DialContext(ctx, "tcp", h.addr, h.SocketMark())
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", h.addr, err)
 	}
@@ -123,9 +124,10 @@ func NewHttp(option HttpOption) *Http {
 
 	return &Http{
 		Base: &Base{
-			name: option.Name,
-			addr: net.JoinHostPort(option.Server, strconv.Itoa(option.Port)),
-			tp:   C.Http,
+			name:       option.Name,
+			addr:       net.JoinHostPort(option.Server, strconv.Itoa(option.Port)),
+			tp:         C.Http,
+			socketmark: option.SocketMark,
 		},
 		user:      option.UserName,
 		pass:      option.Password,

--- a/adapters/outbound/parser.go
+++ b/adapters/outbound/parser.go
@@ -71,6 +71,13 @@ func ParseProxy(mapping map[string]interface{}) (C.Proxy, error) {
 			break
 		}
 		proxy, err = NewTrojan(*trojanOption)
+	case "direct":
+		directOption := &DirectOption{}
+		err = decoder.Decode(mapping, directOption)
+		if err != nil {
+			break
+		}
+		proxy = NewDirectWithOption(*directOption)
 	default:
 		return nil, fmt.Errorf("Unsupport proxy type: %s", proxyType)
 	}

--- a/adapters/outbound/shadowsocks.go
+++ b/adapters/outbound/shadowsocks.go
@@ -38,6 +38,7 @@ type ShadowSocksOption struct {
 	Plugin     string                 `proxy:"plugin,omitempty"`
 	PluginOpts map[string]interface{} `proxy:"plugin-opts,omitempty"`
 	SocketMark string                 `proxy:"socket-mark,omitempty"`
+	Interface  string                 `proxy:"interface-name,omitempty"`
 }
 
 type simpleObfsOption struct {
@@ -75,7 +76,7 @@ func (ss *ShadowSocks) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, e
 }
 
 func (ss *ShadowSocks) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", ss.addr, ss.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", ss.addr, dialer.DialOptions{SocketMark: ss.SocketMark(), Interface: ss.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", ss.addr, err)
 	}
@@ -162,6 +163,7 @@ func NewShadowSocks(option ShadowSocksOption) (*ShadowSocks, error) {
 			tp:         C.Shadowsocks,
 			udp:        option.UDP,
 			socketmark: option.SocketMark,
+			ifname:     option.Interface,
 		},
 		cipher: ciph,
 

--- a/adapters/outbound/shadowsocks.go
+++ b/adapters/outbound/shadowsocks.go
@@ -37,6 +37,7 @@ type ShadowSocksOption struct {
 	UDP        bool                   `proxy:"udp,omitempty"`
 	Plugin     string                 `proxy:"plugin,omitempty"`
 	PluginOpts map[string]interface{} `proxy:"plugin-opts,omitempty"`
+	SocketMark string                 `proxy:"socket-mark,omitempty"`
 }
 
 type simpleObfsOption struct {
@@ -74,7 +75,7 @@ func (ss *ShadowSocks) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, e
 }
 
 func (ss *ShadowSocks) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", ss.addr)
+	c, err := dialer.DialContext(ctx, "tcp", ss.addr, ss.SocketMark())
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", ss.addr, err)
 	}
@@ -156,10 +157,11 @@ func NewShadowSocks(option ShadowSocksOption) (*ShadowSocks, error) {
 
 	return &ShadowSocks{
 		Base: &Base{
-			name: option.Name,
-			addr: addr,
-			tp:   C.Shadowsocks,
-			udp:  option.UDP,
+			name:       option.Name,
+			addr:       addr,
+			tp:         C.Shadowsocks,
+			udp:        option.UDP,
+			socketmark: option.SocketMark,
 		},
 		cipher: ciph,
 

--- a/adapters/outbound/shadowsocksr.go
+++ b/adapters/outbound/shadowsocksr.go
@@ -33,6 +33,7 @@ type ShadowSocksROption struct {
 	Protocol      string `proxy:"protocol"`
 	ProtocolParam string `proxy:"protocol-param,omitempty"`
 	UDP           bool   `proxy:"udp,omitempty"`
+	SocketMark    string `proxy:"socket-mark",omitempty"`
 }
 
 func (ssr *ShadowSocksR) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
@@ -52,7 +53,7 @@ func (ssr *ShadowSocksR) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn,
 }
 
 func (ssr *ShadowSocksR) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", ssr.addr)
+	c, err := dialer.DialContext(ctx, "tcp", ssr.addr, ssr.SocketMark())
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", ssr.addr, err)
 	}
@@ -122,10 +123,11 @@ func NewShadowSocksR(option ShadowSocksROption) (*ShadowSocksR, error) {
 
 	return &ShadowSocksR{
 		Base: &Base{
-			name: option.Name,
-			addr: addr,
-			tp:   C.ShadowsocksR,
-			udp:  option.UDP,
+			name:       option.Name,
+			addr:       addr,
+			tp:         C.ShadowsocksR,
+			udp:        option.UDP,
+			socketmark: option.SocketMark,
 		},
 		cipher:   ciph,
 		obfs:     obfs,

--- a/adapters/outbound/shadowsocksr.go
+++ b/adapters/outbound/shadowsocksr.go
@@ -34,6 +34,7 @@ type ShadowSocksROption struct {
 	ProtocolParam string `proxy:"protocol-param,omitempty"`
 	UDP           bool   `proxy:"udp,omitempty"`
 	SocketMark    string `proxy:"socket-mark",omitempty"`
+	Interface     string `proxy:"interface-name,omitempty"`
 }
 
 func (ssr *ShadowSocksR) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
@@ -53,7 +54,7 @@ func (ssr *ShadowSocksR) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn,
 }
 
 func (ssr *ShadowSocksR) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", ssr.addr, ssr.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", ssr.addr, dialer.DialOptions{SocketMark: ssr.SocketMark(), Interface: ssr.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", ssr.addr, err)
 	}
@@ -128,6 +129,7 @@ func NewShadowSocksR(option ShadowSocksROption) (*ShadowSocksR, error) {
 			tp:         C.ShadowsocksR,
 			udp:        option.UDP,
 			socketmark: option.SocketMark,
+			ifname:     option.Interface,
 		},
 		cipher:   ciph,
 		obfs:     obfs,

--- a/adapters/outbound/snell.go
+++ b/adapters/outbound/snell.go
@@ -26,6 +26,7 @@ type SnellOption struct {
 	Psk        string                 `proxy:"psk"`
 	ObfsOpts   map[string]interface{} `proxy:"obfs-opts,omitempty"`
 	SocketMark string                 `proxy:"socket-mark,omitempty"`
+	Interface  string                 `proxy:"interface-name,omitempty"`
 }
 
 func (s *Snell) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
@@ -43,7 +44,7 @@ func (s *Snell) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (s *Snell) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", s.addr, s.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", s.addr, dialer.DialOptions{SocketMark: s.SocketMark(), Interface: s.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", s.addr, err)
 	}
@@ -73,6 +74,7 @@ func NewSnell(option SnellOption) (*Snell, error) {
 			addr:       addr,
 			tp:         C.Snell,
 			socketmark: option.SocketMark,
+			ifname:     option.Interface,
 		},
 		psk:        psk,
 		obfsOption: obfsOption,

--- a/adapters/outbound/snell.go
+++ b/adapters/outbound/snell.go
@@ -20,11 +20,12 @@ type Snell struct {
 }
 
 type SnellOption struct {
-	Name     string                 `proxy:"name"`
-	Server   string                 `proxy:"server"`
-	Port     int                    `proxy:"port"`
-	Psk      string                 `proxy:"psk"`
-	ObfsOpts map[string]interface{} `proxy:"obfs-opts,omitempty"`
+	Name       string                 `proxy:"name"`
+	Server     string                 `proxy:"server"`
+	Port       int                    `proxy:"port"`
+	Psk        string                 `proxy:"psk"`
+	ObfsOpts   map[string]interface{} `proxy:"obfs-opts,omitempty"`
+	SocketMark string                 `proxy:"socket-mark,omitempty"`
 }
 
 func (s *Snell) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
@@ -42,7 +43,7 @@ func (s *Snell) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (s *Snell) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", s.addr)
+	c, err := dialer.DialContext(ctx, "tcp", s.addr, s.SocketMark())
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", s.addr, err)
 	}
@@ -68,9 +69,10 @@ func NewSnell(option SnellOption) (*Snell, error) {
 
 	return &Snell{
 		Base: &Base{
-			name: option.Name,
-			addr: addr,
-			tp:   C.Snell,
+			name:       option.Name,
+			addr:       addr,
+			tp:         C.Snell,
+			socketmark: option.SocketMark,
 		},
 		psk:        psk,
 		obfsOption: obfsOption,

--- a/adapters/outbound/socks5.go
+++ b/adapters/outbound/socks5.go
@@ -34,6 +34,7 @@ type Socks5Option struct {
 	UDP            bool   `proxy:"udp,omitempty"`
 	SkipCertVerify bool   `proxy:"skip-cert-verify,omitempty"`
 	SocketMark     string `proxy:"socket-mark,omitempty"`
+	Interface      string `proxy:"interface-name,omitempty"`
 }
 
 func (ss *Socks5) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
@@ -60,7 +61,7 @@ func (ss *Socks5) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error)
 }
 
 func (ss *Socks5) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", ss.addr, ss.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", ss.addr, dialer.DialOptions{SocketMark: ss.SocketMark(), Interface: ss.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", ss.addr, err)
 	}
@@ -77,7 +78,7 @@ func (ss *Socks5) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn
 func (ss *Socks5) DialUDP(metadata *C.Metadata) (_ C.PacketConn, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), tcpTimeout)
 	defer cancel()
-	c, err := dialer.DialContext(ctx, "tcp", ss.addr, ss.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", ss.addr, dialer.DialOptions{SocketMark: ss.SocketMark(), Interface: ss.Interface()})
 	if err != nil {
 		err = fmt.Errorf("%s connect error: %w", ss.addr, err)
 		return
@@ -143,6 +144,7 @@ func NewSocks5(option Socks5Option) *Socks5 {
 			tp:         C.Socks5,
 			udp:        option.UDP,
 			socketmark: option.SocketMark,
+			ifname:     option.Interface,
 		},
 		user:           option.UserName,
 		pass:           option.Password,

--- a/adapters/outbound/trojan.go
+++ b/adapters/outbound/trojan.go
@@ -27,6 +27,7 @@ type TrojanOption struct {
 	SkipCertVerify bool     `proxy:"skip-cert-verify,omitempty"`
 	UDP            bool     `proxy:"udp,omitempty"`
 	SocketMark     string   `proxy:"socket-mark,omitempty"`
+	Interface      string   `proxy:"interface-name,omitempty"`
 }
 
 func (t *Trojan) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
@@ -40,7 +41,7 @@ func (t *Trojan) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) 
 }
 
 func (t *Trojan) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", t.addr, t.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", t.addr, dialer.DialOptions{SocketMark: t.SocketMark(), Interface: t.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", t.addr, err)
 	}
@@ -56,7 +57,7 @@ func (t *Trojan) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn,
 func (t *Trojan) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), tcpTimeout)
 	defer cancel()
-	c, err := dialer.DialContext(ctx, "tcp", t.addr, t.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", t.addr, dialer.DialOptions{SocketMark: t.SocketMark(), Interface: t.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %w", t.addr, err)
 	}
@@ -103,6 +104,7 @@ func NewTrojan(option TrojanOption) (*Trojan, error) {
 			tp:         C.Trojan,
 			udp:        option.UDP,
 			socketmark: option.SocketMark,
+			ifname:     option.Interface,
 		},
 		instance: trojan.New(tOption),
 	}, nil

--- a/adapters/outbound/vmess.go
+++ b/adapters/outbound/vmess.go
@@ -37,6 +37,7 @@ type VmessOption struct {
 	SkipCertVerify bool              `proxy:"skip-cert-verify,omitempty"`
 	ServerName     string            `proxy:"servername,omitempty"`
 	SocketMark     string            `proxy:"socket-mark,omitempty"`
+	Interface      string            `proxy:"interface-name,omitempty"`
 }
 
 type HTTPOptions struct {
@@ -107,7 +108,7 @@ func (v *Vmess) StreamConn(c net.Conn, metadata *C.Metadata) (net.Conn, error) {
 }
 
 func (v *Vmess) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	c, err := dialer.DialContext(ctx, "tcp", v.addr, v.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", v.addr, dialer.DialOptions{SocketMark: v.SocketMark(), Interface: v.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %s", v.addr, err.Error())
 	}
@@ -129,7 +130,7 @@ func (v *Vmess) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), tcpTimeout)
 	defer cancel()
-	c, err := dialer.DialContext(ctx, "tcp", v.addr, v.SocketMark())
+	c, err := dialer.DialContext(ctx, "tcp", v.addr, dialer.DialOptions{SocketMark: v.SocketMark(), Interface: v.Interface()})
 	if err != nil {
 		return nil, fmt.Errorf("%s connect error: %s", v.addr, err.Error())
 	}
@@ -161,6 +162,7 @@ func NewVmess(option VmessOption) (*Vmess, error) {
 			tp:         C.Vmess,
 			udp:        true,
 			socketmark: option.SocketMark,
+			ifname:     option.Interface,
 		},
 		client: client,
 		option: &option,

--- a/adapters/provider/vehicle.go
+++ b/adapters/provider/vehicle.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -99,7 +100,9 @@ func (h *HTTPVehicle) Read() ([]byte, error) {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		DialContext:           dialer.DialContext,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		},
 	}
 
 	client := http.Client{Transport: transport}

--- a/common/sockopt/sobind_darwin.go
+++ b/common/sockopt/sobind_darwin.go
@@ -1,0 +1,19 @@
+package sockopt
+
+import (
+	"github.com/Dreamacro/clash/log"
+	"net"
+	"syscall"
+)
+
+func BindToDevice(dialer *net.Dialer, ifname string) {
+	iface, err := net.InterfaceByName(ifname)
+
+	dialer.Control = func(network, address string, c syscall.RawConn) error {
+		return c.Control(func(fd uintptr) {
+			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_BOUND_IF, iface.index); err != nil {
+				log.Errorln("Sockopt IP_BOUND_IP error: %s", err)
+			}
+		})
+	}
+}

--- a/common/sockopt/sobind_linux.go
+++ b/common/sockopt/sobind_linux.go
@@ -1,0 +1,17 @@
+package sockopt
+
+import (
+	"github.com/Dreamacro/clash/log"
+	"net"
+	"syscall"
+)
+
+func BindToDevice(dialer *net.Dialer, ifname string) {
+	dialer.Control = func(network, address string, c syscall.RawConn) error {
+		return c.Control(func(fd uintptr) {
+			if err := syscall.BindToDevice(int(fd), ifname); err != nil {
+				log.Errorln("Sockopt SO_BINDTODEVICE error: %s", err)
+			}
+		})
+	}
+}

--- a/common/sockopt/sobind_other.go
+++ b/common/sockopt/sobind_other.go
@@ -1,0 +1,12 @@
+// +build !linux,!darwin
+
+package sockopt
+
+import (
+	"net"
+)
+
+func BindToDevice(dialer *net.Dialer, ifname string) {
+	// TODO: Implement for other OSs
+	return
+}

--- a/common/sockopt/somark_linux.go
+++ b/common/sockopt/somark_linux.go
@@ -1,0 +1,17 @@
+package sockopt
+
+import (
+	"github.com/Dreamacro/clash/log"
+	"net"
+	"syscall"
+)
+
+func Mark(dialer *net.Dialer, mark int) {
+	dialer.Control = func(network, address string, c syscall.RawConn) error {
+		return c.Control(func(fd uintptr) {
+			if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, mark); err != nil {
+				log.Errorln("Sockopt SO_MARK error: %s", err)
+			}
+		})
+	}
+}

--- a/common/sockopt/somark_other.go
+++ b/common/sockopt/somark_other.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package sockopt
+
+import (
+	"net"
+)
+
+func Mark(dialer *net.Dialer, mark int) {
+	return
+}

--- a/component/dialer/dialer.go
+++ b/component/dialer/dialer.go
@@ -9,6 +9,11 @@ import (
 	"strconv"
 )
 
+type DialOptions struct {
+	SocketMark string
+	Interface  string
+}
+
 func Dialer() (*net.Dialer, error) {
 	dialer := &net.Dialer{}
 	if DialerHook != nil {
@@ -35,7 +40,7 @@ func Dial(network, address string) (net.Conn, error) {
 	return DialContext(context.Background(), network, address)
 }
 
-func DialContext(ctx context.Context, network, address string, mark ...string) (net.Conn, error) {
+func DialContext(ctx context.Context, network, address string, opts ...DialOptions) (net.Conn, error) {
 	switch network {
 	case "tcp4", "tcp6", "udp4", "udp6":
 		host, port, err := net.SplitHostPort(address)
@@ -45,12 +50,13 @@ func DialContext(ctx context.Context, network, address string, mark ...string) (
 
 		dialer, err := Dialer()
 
-		if mark != nil {
-			markint, err := strconv.Atoi(mark[0])
+		if opts != nil {
+			markint, err := strconv.Atoi(opts[0].SocketMark)
 			if err == nil {
 				sockopt.Mark(dialer, markint)
 			}
 
+			sockopt.BindToDevice(dialer, opts[0].Interface)
 		}
 
 		if err != nil {
@@ -76,7 +82,7 @@ func DialContext(ctx context.Context, network, address string, mark ...string) (
 		}
 		return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
 	case "tcp", "udp":
-		return dualStackDialContext(ctx, network, address, mark)
+		return dualStackDialContext(ctx, network, address, opts)
 	default:
 		return nil, errors.New("network invalid")
 	}
@@ -98,7 +104,7 @@ func ListenPacket(network, address string) (net.PacketConn, error) {
 	return lc.ListenPacket(context.Background(), network, address)
 }
 
-func dualStackDialContext(ctx context.Context, network, address string, mark []string) (net.Conn, error) {
+func dualStackDialContext(ctx context.Context, network, address string, opts []DialOptions) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
@@ -135,11 +141,12 @@ func dualStackDialContext(ctx context.Context, network, address string, mark []s
 			return
 		}
 
-		if mark != nil {
-			markint, err := strconv.Atoi(mark[0])
+		if opts != nil {
+			markint, err := strconv.Atoi(opts[0].SocketMark)
 			if err == nil {
 				sockopt.Mark(dialer, markint)
 			}
+			sockopt.BindToDevice(dialer, opts[0].Interface)
 		}
 
 		var ip net.IP

--- a/component/dialer/hook.go
+++ b/component/dialer/hook.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Dreamacro/clash/common/singledo"
+	"github.com/Dreamacro/clash/common/sockopt"
 )
 
 type DialerHookFunc = func(dialer *net.Dialer) error
@@ -105,44 +106,8 @@ func ListenPacketWithInterface(name string) ListenPacketHookFunc {
 }
 
 func DialerWithInterface(name string) DialHookFunc {
-	single := singledo.NewSingle(5 * time.Second)
-
 	return func(dialer *net.Dialer, network string, ip net.IP) error {
-		elm, err, _ := single.Do(func() (interface{}, error) {
-			iface, err := net.InterfaceByName(name)
-			if err != nil {
-				return nil, err
-			}
-
-			addrs, err := iface.Addrs()
-			if err != nil {
-				return nil, err
-			}
-
-			return addrs, nil
-		})
-
-		if err != nil {
-			return err
-		}
-
-		addrs := elm.([]net.Addr)
-
-		switch network {
-		case "tcp", "tcp4", "tcp6":
-			if addr, err := lookupTCPAddr(ip, addrs); err == nil {
-				dialer.LocalAddr = addr
-			} else {
-				return err
-			}
-		case "udp", "udp4", "udp6":
-			if addr, err := lookupUDPAddr(ip, addrs); err == nil {
-				dialer.LocalAddr = addr
-			} else {
-				return err
-			}
-		}
-
+		sockopt.BindToDevice(dialer, name)
 		return nil
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -259,7 +259,7 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	groupsConfig := cfg.ProxyGroup
 	providersConfig := cfg.ProxyProvider
 
-	proxies["DIRECT"] = outbound.NewProxy(outbound.NewDirect(cfg.SocketMark))
+	proxies["DIRECT"] = outbound.NewProxy(outbound.NewDirectWithOption(outbound.DirectOption{SocketMark: cfg.SocketMark, Interface: cfg.Interface}))
 	proxies["REJECT"] = outbound.NewProxy(outbound.NewReject())
 	proxyList = append(proxyList, "DIRECT", "REJECT")
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,10 +27,11 @@ import (
 type General struct {
 	Inbound
 	Controller
-	Mode      T.TunnelMode `json:"mode"`
-	LogLevel  log.LogLevel `json:"log-level"`
-	IPv6      bool         `json:"ipv6"`
-	Interface string       `json:"interface-name"`
+	Mode       T.TunnelMode `json:"mode"`
+	LogLevel   log.LogLevel `json:"log-level"`
+	IPv6       bool         `json:"ipv6"`
+	Interface  string       `json:"interface-name"`
+	SocketMark string       `json:"socket-mark"`
 }
 
 // Inbound
@@ -120,6 +121,7 @@ type RawConfig struct {
 	ExternalUI         string       `yaml:"external-ui"`
 	Secret             string       `yaml:"secret"`
 	Interface          string       `yaml:"interface-name"`
+	SocketMark         string       `yaml:"socket-mark"`
 
 	ProxyProvider map[string]map[string]interface{} `yaml:"proxy-providers"`
 	Hosts         map[string]string                 `yaml:"hosts"`
@@ -241,10 +243,11 @@ func parseGeneral(cfg *RawConfig) (*General, error) {
 			ExternalUI:         cfg.ExternalUI,
 			Secret:             cfg.Secret,
 		},
-		Mode:      cfg.Mode,
-		LogLevel:  cfg.LogLevel,
-		IPv6:      cfg.IPv6,
-		Interface: cfg.Interface,
+		Mode:       cfg.Mode,
+		LogLevel:   cfg.LogLevel,
+		IPv6:       cfg.IPv6,
+		Interface:  cfg.Interface,
+		SocketMark: cfg.SocketMark,
 	}, nil
 }
 
@@ -256,7 +259,7 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	groupsConfig := cfg.ProxyGroup
 	providersConfig := cfg.ProxyProvider
 
-	proxies["DIRECT"] = outbound.NewProxy(outbound.NewDirect())
+	proxies["DIRECT"] = outbound.NewProxy(outbound.NewDirect(cfg.SocketMark))
 	proxies["REJECT"] = outbound.NewProxy(outbound.NewReject())
 	proxyList = append(proxyList, "DIRECT", "REJECT")
 


### PR DESCRIPTION
Hi,

Cool project! I'm not sure what the proper contribution guidelines are so let me know if I should modify anything.

This add a simple TCP redirection outbound. This is the same functionality as the `redirect` in V2Ray's `freedom` [protocol](https://www.v2ray.com/en/configuration/protocols/freedom.html). For example, it can be used to redirect traffic to different gateways on a network.

The same functionality can be implemented using `sockopt` mark/tags, but since it differs depending on the Firewall it might be useful for this to be included as part of Clash. I have yet to measure the `sockopt` mark option's performance, but I suspect it might be better. Given that it might make sense to eventually continue with PR https://github.com/Dreamacro/clash/pull/162 and add the ability to mark each outbound with its own `SO_MARK`. 