### PR TITLE
Feature: support domain in fallback filter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ type DNS struct {
 type FallbackFilter struct {
 	GeoIP  bool         `yaml:"geoip"`
 	IPCIDR []*net.IPNet `yaml:"ipcidr"`
+	Domain []string     `yaml:"domain"`
 }
 
 // Experimental config
@@ -103,6 +104,7 @@ type RawDNS struct {
 type RawFallbackFilter struct {
 	GeoIP  bool     `yaml:"geoip"`
 	IPCIDR []string `yaml:"ipcidr"`
+	Domain []string `yaml:"domain"`
 }
 
 type RawConfig struct {
@@ -561,6 +563,7 @@ func parseDNS(cfg RawDNS, hosts *trie.DomainTrie) (*DNS, error) {
 	if fallbackip, err := parseFallbackIPCIDR(cfg.FallbackFilter.IPCIDR); err == nil {
 		dnsCfg.FallbackFilter.IPCIDR = fallbackip
 	}
+	dnsCfg.FallbackFilter.Domain = cfg.FallbackFilter.Domain
 
 	if cfg.UseHosts {
 		dnsCfg.Hosts = hosts

--- a/dns/filters.go
+++ b/dns/filters.go
@@ -4,9 +4,10 @@ import (
 	"net"
 
 	"github.com/Dreamacro/clash/component/mmdb"
+	"github.com/Dreamacro/clash/component/trie"
 )
 
-type fallbackFilter interface {
+type fallbackIPFilter interface {
 	Match(net.IP) bool
 }
 
@@ -23,4 +24,23 @@ type ipnetFilter struct {
 
 func (inf *ipnetFilter) Match(ip net.IP) bool {
 	return inf.ipnet.Contains(ip)
+}
+
+type fallbackDomainFilter interface {
+	Match(domain string) bool
+}
+type domainFilter struct {
+	tree *trie.DomainTrie
+}
+
+func NewDomainFilter(domains []string) *domainFilter {
+	df := domainFilter{tree: trie.New()}
+	for _, domain := range domains {
+		df.tree.Insert(domain, "")
+	}
+	return &df
+}
+
+func (df *domainFilter) Match(domain string) bool {
+	return df.tree.Search(domain) != nil
 }

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -118,6 +118,7 @@ func updateDNS(c *config.DNS) {
 		FallbackFilter: dns.FallbackFilter{
 			GeoIP:  c.FallbackFilter.GeoIP,
 			IPCIDR: c.FallbackFilter.IPCIDR,
+			Domain: c.FallbackFilter.Domain,
 		},
 		Default: c.DefaultNameserver,
 	}


### PR DESCRIPTION
Sometimes domain (e.g. google.com) is resolved to a random IP address in China, the current clash will return the IP from standard nameservers directly, which is not right.

This new config is to always return the result of fallback nameservers if domain or domain suffix is matched.

Fallback Config Example:

```
  fallback-filter:
    geoip: true
    ipcidr:
      - 240.0.0.0/4
      - 0.0.0.0/32
    domain:
      - '+.google.com'
      - '+.facebook.com'
      - '+.youtube.com'
```