### PR TITLE
Feature: reload config on SIGHUP

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,6 +97,20 @@ func main() {
 		log.Fatalln("Parse config error: %s", err.Error())
 	}
 
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGHUP)
+		for range sigCh {
+			log.Infoln("SIGHUP received, reloading config")
+			cfg, err := executor.Parse()
+			if err != nil {
+				log.Warnln("Parse config error: %s", err.Error())
+				continue
+			}
+			executor.ApplyConfig(cfg, true)
+		}
+	}()
+
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	<-sigCh


### PR DESCRIPTION
Currently, to reload the config without restarting clash, the controller API is the only choice, which is not init friendly.

This PR makes clash reload config on SIGHUP. It has been manually tested.

On an unrelated note, I'd like to make two more contributions:

1. Make clash call `ifup`/`ifdown` script when it brings up/tears down the tun interface in tun mode.
2. Make clash reject unmapped fake IPs (IPs in the fake IP range not yet being leased from the DNS) in tun mode.

`#1` is, again, to make clash more init friendly. The routing table can only be manipulated once the tun interface is up, and there is currently no easy way to wait for it other than polling.
`#2` is to prevent the infinite loop where such packets get routed back to the tun interface after they go out. I don't think it's possible to break the loop via packet filtering, since clash does establish legit connections within the fake IP range, and there is no easy way to discern the two cases from the outside.

These contributions only pertain to the closed-source premium version. I wonder if opening feature requests is the only way to expedite their implementations?