### PR TITLE
Feature: Add reject-delay

### DIFF
--- a/adapters/outbound/reject.go
+++ b/adapters/outbound/reject.go
@@ -148,15 +148,14 @@ func (rw *NopConn) process() {
 
 		rw.timer.Reset(interval)
 
-		select {
-		case <-rw.timer.C:
-			rw.mutex.Lock()
-			rw.cond.Broadcast()
-			rw.mutex.Unlock()
+		<-rw.timer.C
 
-			if rw.closeAt.Before(time.Now()) {
-				rw.Close()
-			}
+		rw.mutex.Lock()
+		rw.cond.Broadcast()
+		rw.mutex.Unlock()
+
+		if rw.closeAt.Before(time.Now()) {
+			rw.Close()
 		}
 	}
 }

--- a/adapters/outbound/reject.go
+++ b/adapters/outbound/reject.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strconv"
+	"sync"
 	"time"
 
 	C "github.com/Dreamacro/clash/constant"
@@ -12,50 +14,149 @@ import (
 
 type Reject struct {
 	*Base
+
+	delay time.Duration
 }
 
 func (r *Reject) DialContext(ctx context.Context, metadata *C.Metadata) (C.Conn, error) {
-	return NewConn(&NopConn{}, r), nil
+	srcPort, _ := strconv.Atoi(metadata.SrcPort)
+	dstPort, _ := strconv.Atoi(metadata.DstPort)
+
+	mutex := &sync.Mutex{}
+
+	nop := &NopConn{
+		mutex:   mutex,
+		cond:    sync.NewCond(mutex),
+		timer:   time.NewTimer(r.delay),
+		closed:  false,
+		closeAt: time.Now().Add(r.delay),
+		srcAddr: &net.TCPAddr{IP: metadata.SrcIP, Port: srcPort},
+		dstAddr: &net.TCPAddr{IP: metadata.DstIP, Port: dstPort},
+	}
+
+	go nop.process()
+
+	return NewConn(nop, r), nil
 }
 
 func (r *Reject) DialUDP(metadata *C.Metadata) (C.PacketConn, error) {
 	return nil, errors.New("match reject rule")
 }
 
-func NewReject() *Reject {
+func NewReject(delay time.Duration) *Reject {
 	return &Reject{
 		Base: &Base{
 			name: "REJECT",
 			tp:   C.Reject,
 			udp:  true,
 		},
+		delay: delay,
 	}
 }
 
-type NopConn struct{}
+type NopConn struct {
+	mutex *sync.Mutex
+	cond  *sync.Cond
+	timer *time.Timer
+
+	closed  bool
+	closeAt time.Time
+
+	srcAddr net.Addr
+	dstAddr net.Addr
+}
 
 func (rw *NopConn) Read(b []byte) (int, error) {
+	rw.mutex.Lock()
+	defer rw.mutex.Unlock()
+
+	if rw.closed {
+		return 0, io.EOF
+	} else {
+		rw.cond.Wait()
+	}
+
 	return 0, io.EOF
 }
 
 func (rw *NopConn) Write(b []byte) (int, error) {
-	return 0, io.EOF
+	rw.mutex.Lock()
+	defer rw.mutex.Unlock()
+
+	if rw.closed {
+		return 0, io.EOF
+	}
+
+	return len(b), nil
 }
 
 // Close is fake function for net.Conn
-func (rw *NopConn) Close() error { return nil }
+func (rw *NopConn) Close() error {
+	rw.mutex.Lock()
+	defer rw.mutex.Unlock()
+
+	if !rw.closed {
+		rw.closed = true
+		rw.cond.Broadcast()
+	}
+
+	return nil
+}
 
 // LocalAddr is fake function for net.Conn
-func (rw *NopConn) LocalAddr() net.Addr { return nil }
+func (rw *NopConn) LocalAddr() net.Addr { return rw.srcAddr }
 
 // RemoteAddr is fake function for net.Conn
-func (rw *NopConn) RemoteAddr() net.Addr { return nil }
+func (rw *NopConn) RemoteAddr() net.Addr { return rw.dstAddr }
 
 // SetDeadline is fake function for net.Conn
-func (rw *NopConn) SetDeadline(time.Time) error { return nil }
+func (rw *NopConn) SetDeadline(t time.Time) error {
+	if t.After(rw.closeAt) {
+		return nil
+	}
+
+	interval := time.Until(t)
+	if interval < 0 {
+		interval = 1
+	}
+
+	rw.timer.Reset(interval)
+
+	return nil
+}
 
 // SetReadDeadline is fake function for net.Conn
-func (rw *NopConn) SetReadDeadline(time.Time) error { return nil }
+func (rw *NopConn) SetReadDeadline(t time.Time) error { return rw.SetDeadline(t) }
 
 // SetWriteDeadline is fake function for net.Conn
-func (rw *NopConn) SetWriteDeadline(time.Time) error { return nil }
+func (rw *NopConn) SetWriteDeadline(t time.Time) error { return rw.SetDeadline(t) }
+
+func (rw *NopConn) process() {
+	for {
+		rw.mutex.Lock()
+		closed := rw.closed
+		rw.mutex.Unlock()
+
+		if closed {
+			return
+		}
+
+		interval := time.Until(rw.closeAt)
+		if interval < 0 {
+			interval = 1
+		}
+
+		rw.timer.Reset(interval)
+
+		select {
+		case <-rw.timer.C:
+			rw.mutex.Lock()
+			rw.cond.Broadcast()
+			rw.mutex.Unlock()
+
+			if rw.closeAt.Before(time.Now()) {
+				rw.Close()
+			}
+		}
+	}
+}

--- a/adapters/outbound/reject.go
+++ b/adapters/outbound/reject.go
@@ -70,13 +70,15 @@ func (rw *NopConn) Read(b []byte) (int, error) {
 	rw.mutex.Lock()
 	defer rw.mutex.Unlock()
 
-	if rw.closed {
-		return 0, io.EOF
-	} else {
+	if !rw.closed {
 		rw.cond.Wait()
 	}
 
-	return 0, io.EOF
+	if rw.closed {
+		return 0, io.EOF
+	}
+
+	return 0, io.ErrNoProgress
 }
 
 func (rw *NopConn) Write(b []byte) (int, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Dreamacro/clash/adapters/outbound"
 	"github.com/Dreamacro/clash/adapters/outboundgroup"
@@ -124,6 +125,7 @@ type RawConfig struct {
 	ExternalUI         string       `yaml:"external-ui"`
 	Secret             string       `yaml:"secret"`
 	Interface          string       `yaml:"interface-name"`
+	RejectDelay        int          `yaml:"reject-delay"`
 
 	ProxyProvider map[string]map[string]interface{} `yaml:"proxy-providers"`
 	Hosts         map[string]string                 `yaml:"hosts"`
@@ -261,8 +263,12 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	groupsConfig := cfg.ProxyGroup
 	providersConfig := cfg.ProxyProvider
 
+	if cfg.RejectDelay < 0 {
+		cfg.RejectDelay = 0
+	}
+
 	proxies["DIRECT"] = outbound.NewProxy(outbound.NewDirect())
-	proxies["REJECT"] = outbound.NewProxy(outbound.NewReject())
+	proxies["REJECT"] = outbound.NewProxy(outbound.NewReject(time.Second * time.Duration(cfg.RejectDelay)))
 	proxyList = append(proxyList, "DIRECT", "REJECT")
 
 	// parse proxy


### PR DESCRIPTION
为 REJECT 添加连接关闭延迟

**NonConn 的行为变更**
`NonConn` 行为修改为与 `/dev/null` 行为一致 Write 立即返回 Read 等待延迟超时 
目的是保证 inbound 相对于 outbound 更早的关闭时 能立即释放与该连接关联的 goroutine 资源


**示例配置**
```yaml
port: 8080
...
reject-delay: 60
...
rules:
  - MATCH,REJECT
```