### PR TITLE
Feature: support ShadowSocks inbound

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,14 +35,17 @@ type General struct {
 
 // Inbound
 type Inbound struct {
-	Port           int      `json:"port"`
-	SocksPort      int      `json:"socks-port"`
-	RedirPort      int      `json:"redir-port"`
-	TProxyPort     int      `json:"tproxy-port"`
-	MixedPort      int      `json:"mixed-port"`
-	Authentication []string `json:"authentication"`
-	AllowLan       bool     `json:"allow-lan"`
-	BindAddress    string   `json:"bind-address"`
+	Port                int      `json:"port"`
+	SocksPort           int      `json:"socks-port"`
+	RedirPort           int      `json:"redir-port"`
+	TProxyPort          int      `json:"tproxy-port"`
+	MixedPort           int      `json:"mixed-port"`
+	ShadowSocksPort     int      `json:"shadowsocks-port"`
+	ShadowSocksMethod   string   `json:"shadowsocks-method"`
+	ShadowSocksPassword string   `json:"shadowsocks-password"`
+	Authentication      []string `json:"authentication"`
+	AllowLan            bool     `json:"allow-lan"`
+	BindAddress         string   `json:"bind-address"`
 }
 
 // Controller
@@ -109,21 +112,24 @@ type RawFallbackFilter struct {
 }
 
 type RawConfig struct {
-	Port               int          `yaml:"port"`
-	SocksPort          int          `yaml:"socks-port"`
-	RedirPort          int          `yaml:"redir-port"`
-	TProxyPort         int          `yaml:"tproxy-port"`
-	MixedPort          int          `yaml:"mixed-port"`
-	Authentication     []string     `yaml:"authentication"`
-	AllowLan           bool         `yaml:"allow-lan"`
-	BindAddress        string       `yaml:"bind-address"`
-	Mode               T.TunnelMode `yaml:"mode"`
-	LogLevel           log.LogLevel `yaml:"log-level"`
-	IPv6               bool         `yaml:"ipv6"`
-	ExternalController string       `yaml:"external-controller"`
-	ExternalUI         string       `yaml:"external-ui"`
-	Secret             string       `yaml:"secret"`
-	Interface          string       `yaml:"interface-name"`
+	Port                int          `yaml:"port"`
+	SocksPort           int          `yaml:"socks-port"`
+	RedirPort           int          `yaml:"redir-port"`
+	TProxyPort          int          `yaml:"tproxy-port"`
+	MixedPort           int          `yaml:"mixed-port"`
+	ShadowSocksPort     int          `yaml:"shadowsocks-port"`
+	ShadowSocksMethod   string       `yaml:"shadowsocks-method"`
+	ShadowSocksPassword string       `yaml:"shadowsocks-password"`
+	Authentication      []string     `yaml:"authentication"`
+	AllowLan            bool         `yaml:"allow-lan"`
+	BindAddress         string       `yaml:"bind-address"`
+	Mode                T.TunnelMode `yaml:"mode"`
+	LogLevel            log.LogLevel `yaml:"log-level"`
+	IPv6                bool         `yaml:"ipv6"`
+	ExternalController  string       `yaml:"external-controller"`
+	ExternalUI          string       `yaml:"external-ui"`
+	Secret              string       `yaml:"secret"`
+	Interface           string       `yaml:"interface-name"`
 
 	ProxyProvider map[string]map[string]interface{} `yaml:"proxy-providers"`
 	Hosts         map[string]string                 `yaml:"hosts"`
@@ -233,13 +239,16 @@ func parseGeneral(cfg *RawConfig) (*General, error) {
 
 	return &General{
 		Inbound: Inbound{
-			Port:        cfg.Port,
-			SocksPort:   cfg.SocksPort,
-			RedirPort:   cfg.RedirPort,
-			TProxyPort:  cfg.TProxyPort,
-			MixedPort:   cfg.MixedPort,
-			AllowLan:    cfg.AllowLan,
-			BindAddress: cfg.BindAddress,
+			Port:                cfg.Port,
+			SocksPort:           cfg.SocksPort,
+			RedirPort:           cfg.RedirPort,
+			TProxyPort:          cfg.TProxyPort,
+			MixedPort:           cfg.MixedPort,
+			ShadowSocksPort:     cfg.ShadowSocksPort,
+			ShadowSocksMethod:   cfg.ShadowSocksMethod,
+			ShadowSocksPassword: cfg.ShadowSocksPassword,
+			AllowLan:            cfg.AllowLan,
+			BindAddress:         cfg.BindAddress,
 		},
 		Controller: Controller{
 			ExternalController: cfg.ExternalController,

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -199,6 +199,10 @@ func updateGeneral(general *config.General, force bool) {
 	if err := P.ReCreateMixed(general.MixedPort); err != nil {
 		log.Errorln("Start Mixed(http and socks5) server error: %s", err.Error())
 	}
+
+	if err := P.ReCreateShadowSocks(general.ShadowSocksPort, general.ShadowSocksMethod, general.ShadowSocksPassword); err != nil {
+		log.Errorln("Start ShadowSocks server error: %s", err.Error())
+	}
 }
 
 func updateUsers(users []auth.AuthUser) {

--- a/proxy/shadowsocks/tcp.go
+++ b/proxy/shadowsocks/tcp.go
@@ -1,0 +1,62 @@
+package shadowsocks
+
+import (
+	"net"
+
+	adapters "github.com/Dreamacro/clash/adapters/inbound"
+	"github.com/Dreamacro/clash/component/socks5"
+	C "github.com/Dreamacro/clash/constant"
+	"github.com/Dreamacro/clash/log"
+	"github.com/Dreamacro/clash/tunnel"
+	"github.com/Dreamacro/go-shadowsocks2/core"
+)
+
+type ShadowSockListener struct {
+	net.Listener
+	address string
+	closed  bool
+}
+
+func NewShadowSocksProxy(addr string, cipher core.Cipher) (*ShadowSockListener, error) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	sl := &ShadowSockListener{l, addr, false}
+
+	go func() {
+		log.Infoln("ShadowSocks proxy listening at: %s", addr)
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				if sl.closed {
+					break
+				}
+				continue
+			}
+			sc := cipher.StreamConn(c)
+			go HandleShadowSocks(sc)
+		}
+	}()
+
+	return sl, nil
+}
+
+func (l *ShadowSockListener) Close() {
+	l.closed = true
+	_ = l.Listener.Close()
+}
+
+func (l *ShadowSockListener) Address() string {
+	return l.address
+}
+
+func HandleShadowSocks(c net.Conn) {
+	tAddr, err := socks5.ReadAddr(c, make([]byte, socks5.MaxAddrLen))
+	if err != nil {
+		return
+	}
+
+	tunnel.Add(adapters.NewSocket(tAddr, c, C.SOCKS))
+}

--- a/proxy/shadowsocks/udp.go
+++ b/proxy/shadowsocks/udp.go
@@ -1,0 +1,67 @@
+package shadowsocks
+
+import (
+	"net"
+
+	adapters "github.com/Dreamacro/clash/adapters/inbound"
+	"github.com/Dreamacro/clash/common/pool"
+	"github.com/Dreamacro/clash/component/socks5"
+	C "github.com/Dreamacro/clash/constant"
+	"github.com/Dreamacro/clash/tunnel"
+	"github.com/Dreamacro/go-shadowsocks2/core"
+)
+
+type ShadowSockUDPListener struct {
+	net.PacketConn
+	address string
+	closed  bool
+}
+
+func NewShadowSocksUDPProxy(addr string, cipher core.Cipher) (*ShadowSockUDPListener, error) {
+	l, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := cipher.PacketConn(l)
+	sl := &ShadowSockUDPListener{pc, addr, false}
+
+	go func() {
+		for {
+			buf := pool.Get(pool.RelayBufferSize)
+			n, rAddr, err := pc.ReadFrom(buf)
+			if err != nil {
+				_ = pool.Put(buf)
+				if sl.closed {
+					break
+				}
+				continue
+			}
+			handleShadowSocksUDP(rAddr, pc, buf[:n])
+		}
+	}()
+
+	return sl, nil
+}
+
+func (l *ShadowSockUDPListener) Close() {
+	l.closed = true
+	_ = l.PacketConn.Close()
+}
+
+func (l *ShadowSockUDPListener) Address() string {
+	return l.address
+}
+
+func handleShadowSocksUDP(rAddr net.Addr, pc net.PacketConn, buf []byte) {
+	tAddr := socks5.SplitAddr(buf)
+	payload := buf[len(tAddr):]
+
+	packet := &packet{
+		pc:      pc,
+		rAddr:   rAddr,
+		payload: payload,
+		bufRef:  buf,
+	}
+	tunnel.AddPacket(adapters.NewPacket(tAddr, packet, C.SOCKS))
+}

--- a/proxy/shadowsocks/utils.go
+++ b/proxy/shadowsocks/utils.go
@@ -1,0 +1,35 @@
+package shadowsocks
+
+import (
+	"bytes"
+	"net"
+
+	"github.com/Dreamacro/clash/common/pool"
+	"github.com/Dreamacro/clash/component/socks5"
+)
+
+type packet struct {
+	pc      net.PacketConn
+	rAddr   net.Addr
+	payload []byte
+	bufRef  []byte
+}
+
+func (c *packet) Data() []byte {
+	return c.payload
+}
+
+func (c *packet) WriteBack(b []byte, addr net.Addr) (n int, err error) {
+	sAddr := socks5.ParseAddr(addr.String())
+	packet := bytes.Join([][]byte{sAddr, b}, []byte{})
+
+	return c.pc.WriteTo(packet, c.rAddr)
+}
+
+func (c *packet) LocalAddr() net.Addr {
+	return c.rAddr
+}
+
+func (c *packet) Drop() {
+	_ = pool.Put(c.bufRef)
+}


### PR DESCRIPTION
新增 ShadowSocks 为代理入口；

之前看到 #34 ，说明大家还是有远程连接到 Clash 的需求。
但 Socks 并不是很适合在公网传输，如果没有使用 Over TLS 的话，数据是明文传输的。

