### PR TITLE
Fix: unnecessary write operation on provider

### DIFF
--- a/adapters/provider/fetcher.go
+++ b/adapters/provider/fetcher.go
@@ -108,8 +108,10 @@ func (f *fetcher) Update() (interface{}, bool, error) {
 		return nil, false, err
 	}
 
-	if err := safeWrite(f.vehicle.Path(), buf); err != nil {
-		return nil, false, err
+	if f.vehicle.Type() != File {
+		if err := safeWrite(f.vehicle.Path(), buf); err != nil {
+			return nil, false, err
+		}
 	}
 
 	f.updatedAt = &now


### PR DESCRIPTION
使用rule-providers，规则自动更新时，如果是规则来源是File类型，会意外的触发一次IO写操作，这里进行了修复。