### PR TITLE
Fix: wrap net.Conn to avoid using *net.TCPConn.(ReadFrom)

### DIFF
--- a/common/net/io.go
+++ b/common/net/io.go
@@ -1,4 +1,4 @@
-package wrapper
+package net
 
 import "io"
 

--- a/common/wrapper/io.go
+++ b/common/wrapper/io.go
@@ -1,0 +1,11 @@
+package wrapper
+
+import "io"
+
+type ReadOnlyReader struct {
+	io.Reader
+}
+
+type WriteOnlyWriter struct {
+	io.Writer
+}

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -142,6 +142,8 @@ func relay(leftConn, rightConn net.Conn) {
 
 	go func() {
 		buf := pool.Get(pool.RelayBufferSize)
+		// Wrapping to avoid using *net.TCPConn.(ReadFrom)
+		// See also https://github.com/Dreamacro/clash/pull/1209
 		_, err := io.CopyBuffer(N.WriteOnlyWriter{Writer: leftConn}, N.ReadOnlyReader{Reader: rightConn}, buf)
 		pool.Put(buf)
 		leftConn.SetReadDeadline(time.Now())

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/Dreamacro/clash/adapters/inbound"
+	N "github.com/Dreamacro/clash/common/net"
 	"github.com/Dreamacro/clash/common/pool"
-	"github.com/Dreamacro/clash/common/wrapper"
 	"github.com/Dreamacro/clash/component/resolver"
 	C "github.com/Dreamacro/clash/constant"
 	"github.com/Dreamacro/clash/context"
@@ -142,14 +142,14 @@ func relay(leftConn, rightConn net.Conn) {
 
 	go func() {
 		buf := pool.Get(pool.RelayBufferSize)
-		_, err := io.CopyBuffer(wrapper.WriteOnlyWriter{Writer: leftConn}, wrapper.ReadOnlyReader{Reader: rightConn}, buf)
+		_, err := io.CopyBuffer(N.WriteOnlyWriter{Writer: leftConn}, N.ReadOnlyReader{Reader: rightConn}, buf)
 		pool.Put(buf)
 		leftConn.SetReadDeadline(time.Now())
 		ch <- err
 	}()
 
 	buf := pool.Get(pool.RelayBufferSize)
-	io.CopyBuffer(wrapper.WriteOnlyWriter{Writer: rightConn}, wrapper.ReadOnlyReader{Reader: leftConn}, buf)
+	io.CopyBuffer(N.WriteOnlyWriter{Writer: rightConn}, N.ReadOnlyReader{Reader: leftConn}, buf)
 	pool.Put(buf)
 	rightConn.SetReadDeadline(time.Now())
 	<-ch


### PR DESCRIPTION
考虑这样的情况

在传入参数有任意一个是 *net.TCPConn (当然 rightConn 不可能是 TCP 毕竟有 TcpTracker

https://github.com/Dreamacro/clash/blob/3600077f3b6997c7b9e7a42a69afde6b17a5e5b1/tunnel/connection.go#L134-L151

调用到

```go
func CopyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
	if buf != nil && len(buf) == 0 {
		panic("empty buffer in CopyBuffer")
	}
	return copyBuffer(dst, src, buf)
}
```

再往下

```go
func copyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
	// If the reader has a WriteTo method, use it to do the copy.
	// Avoids an allocation and a copy.
	if wt, ok := src.(WriterTo); ok {
		return wt.WriteTo(dst)
	}
	// Similarly, if the writer has a ReadFrom method, use it to do the copy.
	if rt, ok := dst.(ReaderFrom); ok {
		return rt.ReadFrom(src) // 到此为止
	}
        
        // Copy 
        ......
}
```

由于 *net.TCPConn 实现了 ReadFrom 函数会直接交给 *net.TCPConn.(ReadFrom) 处理

```go
// ReadFrom implements the io.ReaderFrom ReadFrom method.
func (c *TCPConn) ReadFrom(r io.Reader) (int64, error) {
	if !c.ok() {
		return 0, syscall.EINVAL
	}
	n, err := c.readFrom(r) // 实现
	if err != nil && err != io.EOF {
		err = &OpError{Op: "readfrom", Net: c.fd.net, Source: c.fd.laddr, Addr: c.fd.raddr, Err: err}
	}
	return n, err
}
```

可以看到最终的 readFrom 实现
1. 先尝试 Zero Copy - splice
    要求 Reader 是一个 *net.TCPConn
2. 再尝试 Zero Copy - sendFile
    要求 Reader 是一个 *os.File
3. 回退到常规复制
    genericReadFrom

```go
func (c *TCPConn) readFrom(r io.Reader) (int64, error) {
	if n, err, handled := splice(c.fd, r); handled {
		return n, err
	}
	if n, err, handled := sendFile(c.fd, r); handled {
		return n, err
	}
	return genericReadFrom(c, r)
}
```

genericReadFrom 的实现
```go
// Fallback implementation of io.ReaderFrom's ReadFrom, when sendfile isn't
// applicable.
func genericReadFrom(w io.Writer, r io.Reader) (n int64, err error) {
	// Use wrapper to hide existing r.ReadFrom from io.Copy.
	return io.Copy(writerOnly{w}, r)
}
```

最终会使 CopyBuffer 使用的 来自 pool 的 buffer 失去意义 (

~~顺便 这个也是之前几个 Zero Copy 实现的原理 可以看到最终会使 TcpTrack 失去作用 (~~