### PR TITLE
Fix: reset udp timeout after sending each packet

### DIFF
--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -107,7 +107,8 @@ func handleUDPToRemote(packet C.UDPPacket, pc C.PacketConn, metadata *C.Metadata
 	if _, err := pc.WriteTo(packet.Data(), addr); err != nil {
 		return err
 	}
-	pc.SetReadDeadline(time.Now().Add(udpTimeout)) /* reset timeout */
+	// reset timeout
+	pc.SetReadDeadline(time.Now().Add(udpTimeout))
 
 	return nil
 }

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -104,8 +104,12 @@ func handleUDPToRemote(packet C.UDPPacket, pc C.PacketConn, metadata *C.Metadata
 		return errors.New("udp addr invalid")
 	}
 
-	_, err := pc.WriteTo(packet.Data(), addr)
-	return err
+	if _, err := pc.WriteTo(packet.Data(), addr); err != nil {
+		return err
+	}
+	pc.SetReadDeadline(time.Now().Add(udpTimeout))
+
+	return nil
 }
 
 func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, fAddr net.Addr) {

--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -107,7 +107,7 @@ func handleUDPToRemote(packet C.UDPPacket, pc C.PacketConn, metadata *C.Metadata
 	if _, err := pc.WriteTo(packet.Data(), addr); err != nil {
 		return err
 	}
-	pc.SetReadDeadline(time.Now().Add(udpTimeout))
+	pc.SetReadDeadline(time.Now().Add(udpTimeout)) /* reset timeout */
 
 	return nil
 }


### PR DESCRIPTION
实际使用里有些依赖UDP的协议只会发送但不一定会有回复（比如有些心跳包），所以UDP的会话超时机制应该取决于两侧是否有活跃的包传输，而不是仅靠一侧的readfrom来实现。

