### PR TITLE
Fix: set metadata.AddrType if host is ip string after remove host

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -122,6 +122,11 @@ func preHandleMetadata(metadata *C.Metadata) error {
 	if ip := net.ParseIP(metadata.Host); ip != nil {
 		metadata.DstIP = ip
 		metadata.Host = ""
+		if len(ip) == net.IPv4len {
+			metadata.AddrType = C.AtypIPv4
+		} else {
+			metadata.AddrType = C.AtypIPv6
+		}
 	}
 
 	// preprocess enhanced-mode metadata

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -122,7 +122,7 @@ func preHandleMetadata(metadata *C.Metadata) error {
 	if ip := net.ParseIP(metadata.Host); ip != nil {
 		metadata.DstIP = ip
 		metadata.Host = ""
-		if len(ip) == net.IPv4len {
+		if ip.To4() != nil {
 			metadata.AddrType = C.AtypIPv4
 		} else {
 			metadata.AddrType = C.AtypIPv6


### PR DESCRIPTION
防止出现`metadata.AddrType=C.AtypDomainName`而`metadata.Host=""`的情况