### PR TITLE
[New Feature] Use mixed-port instead of port

### DIFF
--- a/config/initial.go
+++ b/config/initial.go
@@ -66,7 +66,7 @@ func Init(dir string) error {
 		if err != nil {
 			return fmt.Errorf("can't create file %s: %s", C.Path.Config(), err.Error())
 		}
-		f.Write([]byte(`port: 7890`))
+		f.Write([]byte(`mixed-port: 7890`))
 		f.Close()
 	}
 


### PR DESCRIPTION
Since ``mixed-port`` support both ``socks5`` and ``http`` inbound, there is no need for a initial config to accept ``socks5`` only