### PR TITLE
feat: initial support unspport networkstack fallback, implement #1326

### DIFF
--- a/adapters/outbound/base.go
+++ b/adapters/outbound/base.go
@@ -19,6 +19,8 @@ type Base struct {
 	addr string
 	tp   C.AdapterType
 	udp  bool
+	ipv4 bool
+	ipv6 bool
 }
 
 func (b *Base) Name() string {
@@ -41,6 +43,14 @@ func (b *Base) SupportUDP() bool {
 	return b.udp
 }
 
+func (b *Base) SupportIpv4() bool {
+	return b.ipv4
+}
+
+func (b *Base) SupportIpv6() bool {
+	return b.ipv6
+}
+
 func (b *Base) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{
 		"type": b.Type().String(),
@@ -55,8 +65,8 @@ func (b *Base) Unwrap(metadata *C.Metadata) C.Proxy {
 	return nil
 }
 
-func NewBase(name string, addr string, tp C.AdapterType, udp bool) *Base {
-	return &Base{name, addr, tp, udp}
+func NewBase(name string, addr string, tp C.AdapterType, udp bool, ipv4 bool, ipv6 bool) *Base {
+	return &Base{name, addr, tp, udp, ipv4, ipv6}
 }
 
 type conn struct {

--- a/adapters/outboundgroup/fallback.go
+++ b/adapters/outboundgroup/fallback.go
@@ -87,7 +87,7 @@ func (f *Fallback) findAliveProxy(touch bool) C.Proxy {
 
 func NewFallback(options *GroupCommonOption, providers []provider.ProxyProvider) *Fallback {
 	return &Fallback{
-		Base:       outbound.NewBase(options.Name, "", C.Fallback, false),
+		Base:       outbound.NewBase(options.Name, "", C.Fallback, false, true, false),
 		single:     singledo.NewSingle(defaultGetProxiesDuration),
 		providers:  providers,
 		disableUDP: options.DisableUDP,

--- a/adapters/outboundgroup/loadbalance.go
+++ b/adapters/outboundgroup/loadbalance.go
@@ -165,7 +165,7 @@ func NewLoadBalance(options *GroupCommonOption, providers []provider.ProxyProvid
 		return nil, fmt.Errorf("%w: %s", errStrategy, strategy)
 	}
 	return &LoadBalance{
-		Base:       outbound.NewBase(options.Name, "", C.LoadBalance, false),
+		Base:       outbound.NewBase(options.Name, "", C.LoadBalance, false, true, false),
 		single:     singledo.NewSingle(defaultGetProxiesDuration),
 		providers:  providers,
 		strategyFn: strategyFn,

--- a/adapters/outboundgroup/relay.go
+++ b/adapters/outboundgroup/relay.go
@@ -91,7 +91,7 @@ func (r *Relay) proxies(metadata *C.Metadata, touch bool) []C.Proxy {
 
 func NewRelay(options *GroupCommonOption, providers []provider.ProxyProvider) *Relay {
 	return &Relay{
-		Base:      outbound.NewBase(options.Name, "", C.Relay, false),
+		Base:      outbound.NewBase(options.Name, "", C.Relay, false, true, false),
 		single:    singledo.NewSingle(defaultGetProxiesDuration),
 		providers: providers,
 	}

--- a/adapters/outboundgroup/selector.go
+++ b/adapters/outboundgroup/selector.go
@@ -94,7 +94,7 @@ func (s *Selector) selectedProxy(touch bool) C.Proxy {
 func NewSelector(options *GroupCommonOption, providers []provider.ProxyProvider) *Selector {
 	selected := providers[0].Proxies()[0].Name()
 	return &Selector{
-		Base:       outbound.NewBase(options.Name, "", C.Selector, false),
+		Base:       outbound.NewBase(options.Name, "", C.Selector, false, true, false),
 		single:     singledo.NewSingle(defaultGetProxiesDuration),
 		providers:  providers,
 		selected:   selected,

--- a/adapters/outboundgroup/urltest.go
+++ b/adapters/outboundgroup/urltest.go
@@ -124,7 +124,7 @@ func parseURLTestOption(config map[string]interface{}) []urlTestOption {
 
 func NewURLTest(commonOptions *GroupCommonOption, providers []provider.ProxyProvider, options ...urlTestOption) *URLTest {
 	urlTest := &URLTest{
-		Base:       outbound.NewBase(commonOptions.Name, "", C.URLTest, false),
+		Base:       outbound.NewBase(commonOptions.Name, "", C.URLTest, false, true, false),
 		single:     singledo.NewSingle(defaultGetProxiesDuration),
 		fastSingle: singledo.NewSingle(time.Second * 10),
 		providers:  providers,

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -73,6 +73,8 @@ type ProxyAdapter interface {
 	DialContext(ctx context.Context, metadata *Metadata) (Conn, error)
 	DialUDP(metadata *Metadata) (PacketConn, error)
 	SupportUDP() bool
+	SupportIpv4() bool
+	SupportIpv6() bool
 	MarshalJSON() ([]byte, error)
 	Addr() string
 	// Unwrap extracts the proxy from a proxy-group. It returns nil when nothing to extract.

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -166,6 +166,7 @@ func updateRules(rules []C.Rule) {
 func updateGeneral(general *config.General, force bool) {
 	log.SetLevel(general.LogLevel)
 	tunnel.SetMode(general.Mode)
+	tunnel.SetUnsupportNetworkstackFallback(general.UnsupportNetworkstackFallback)
 	resolver.DisableIPv6 = !general.IPv6
 
 	if general.Interface != "" {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -27,7 +27,8 @@ var (
 	configMux sync.RWMutex
 
 	// Outbound Rule
-	mode = Rule
+	mode                          = Rule
+	unsupportNetworkstackFallback = false
 
 	// default timeout for UDP session
 	udpTimeout = 60 * time.Second
@@ -88,6 +89,14 @@ func Mode() TunnelMode {
 // SetMode change the mode of tunnel
 func SetMode(m TunnelMode) {
 	mode = m
+}
+
+func SetUnsupportNetworkstackFallback(f bool) {
+	unsupportNetworkstackFallback = f
+}
+
+func UnsupportNetworkstackFallback() bool {
+	return unsupportNetworkstackFallback
 }
 
 // processUDP starts a loop to handle udp packet
@@ -332,6 +341,15 @@ func match(metadata *C.Metadata) (C.Proxy, C.Rule, error) {
 			if metadata.NetWork == C.UDP && !adapter.SupportUDP() {
 				log.Debugln("%v UDP is not supported", adapter.Name())
 				continue
+			}
+
+			// IPv6 addresses
+			if unsupportNetworkstackFallback && metadata.Host == "" && metadata.DstIP.To4() == nil && !adapter.SupportIpv6() {
+				return proxies["DIRECT"], nil, nil
+			}
+			// IPv4 addresses
+			if unsupportNetworkstackFallback && metadata.Host == "" && metadata.DstIP.To4() != nil && !adapter.SupportIpv4() {
+				return proxies["DIRECT"], nil, nil
 			}
 			return adapter, rule, nil
 		}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -344,11 +344,11 @@ func match(metadata *C.Metadata) (C.Proxy, C.Rule, error) {
 			}
 
 			// IPv6 addresses
-			if unsupportNetworkstackFallback && metadata.Host == "" && metadata.DstIP.To4() == nil && !adapter.SupportIpv6() {
+			if unsupportNetworkstackFallback && metadata.Host == "" && metadata.DstIP.To4() == nil && !adapter.SupportIpv6() && adapter != proxies["DIRECT"] {
 				return proxies["DIRECT"], nil, nil
 			}
 			// IPv4 addresses
-			if unsupportNetworkstackFallback && metadata.Host == "" && metadata.DstIP.To4() != nil && !adapter.SupportIpv4() {
+			if unsupportNetworkstackFallback && metadata.Host == "" && metadata.DstIP.To4() != nil && !adapter.SupportIpv4() && adapter != proxies["DIRECT"] {
 				return proxies["DIRECT"], nil, nil
 			}
 			return adapter, rule, nil


### PR DESCRIPTION
配置

```
---
external-controller: 127.0.0.1:9090
port: 7890
socks-port: 7891
redir-port: 7892
proxies:
- type: trojan
  name: x1.0 香港 6
  server: xx
  port: xx
  password: xx
  udp: true
  skip-cert-verify: false
  ipv4: true
  ipv6: false
- type: ss
  cipher: chacha20-ietf-poly1305
  name: My-JP1-SS
  password: xx
  port: xx
  server: xx
  udp: true
  ipv4: true
  ipv6: true

proxy-groups:
- type: select
  name: "\U0001F680 Proxy"
  proxies:
  - "\U0001F680 Select Proxy"
- type: select
  name: "\U0001F680 Select Proxy"
  proxies:
  - x1.0 香港 6
  - My-JP1-SS

rules:
- GEOIP,CN,DIRECT
- "MATCH,\U0001F680 Proxy"
dns:
  nameserver:
  - 114.114.114.114
  enable: true
  ipv6: true
  enhanced-mode: redir-host
  listen: 0.0.0.0:7874
tproxy-port: 7895
mixed-port: 7893
mode: rule
log-level: info
allow-lan: true
secret: '123456'
bind-address: "*"
ipv6: true
unsupport-networkstack-fallback: true
profile:
  store-selected: true

```

分别通过域名和 IP 通过香港6 访问 http://ip6.me/api/

效果一：

通过域名访问，触发 Match() 规则
```
time="2021-04-02T21:31:31+08:00" level=info msg="[TCP] 127.0.0.1:62712 --> ip6.me match Match() using 🚀 Proxy[x1.0 香港 6]"
```

```
$ curl -x socks5h://127.0.0.1:7893 http://ip6.me/api/ -v -6
*   Trying ::ffff:127.0.0.1:7893...
* SOCKS5 connect to ip6.me:80 (remotely resolved)
* SOCKS5 request granted.
* Connected to 127.0.0.1 (::ffff:127.0.0.1) port 7893 (#0)
> GET /api/ HTTP/1.1
> Host: ip6.me
> User-Agent: curl/7.71.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Fri, 02 Apr 2021 13:31:31 GMT
< Server: Apache/2.4.46 (FreeBSD) OpenSSL/1.1.1d-freebsd
< Expires: 0
< Cache-control: no-cache
< Pragma: no-cache
< Content-Length: 64
< Content-Type: text/plain
<
IPv4,103.xxx.xx.xxx,Remaining fields reserved for future use,,,
* Connection #0 to host 127.0.0.1 left intact
```

效果二：

通过 IP 访问，由于地址是 IPv6，且节点不支持 v6，走直连，得到本地的 IPv6 IP
```
time="2021-04-02T21:31:50+08:00" level=info msg="[TCP] 127.0.0.1:62799 --> 2604:90:1:1::69 doesn't match any rule using DIRECT"
```

```
$ curl -x socks5://127.0.0.1:7893 http://ip6.me/api/ -v -6
*   Trying ::ffff:127.0.0.1:7893...
* SOCKS5 connect to IPv6 2604:90:1:1::69:80 (locally resolved)
* SOCKS5 request granted.
* Connected to 127.0.0.1 (::ffff:127.0.0.1) port 7893 (#0)
> GET /api/ HTTP/1.1
> Host: ip6.me
> User-Agent: curl/7.71.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Fri, 02 Apr 2021 13:31:50 GMT
< Server: Apache/2.4.46 (FreeBSD) OpenSSL/1.1.1d-freebsd
< Expires: 0
< Cache-control: no-cache
< Pragma: no-cache
< Content-Length: 87
< Content-Type: text/plain
<
IPv6,240e:3b7:xxxxxxx,Remaining fields reserved for future use,,,
* Connection #0 to host 127.0.0.1 left intact
```