### PR TITLE
Support dynamic prefix IPv6 CIDR

### DIFF
--- a/rules/ipcidr.go
+++ b/rules/ipcidr.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"net"
+	"strings"
 
 	C "github.com/Dreamacro/clash/constant"
 )
@@ -37,6 +38,10 @@ func (i *IPCIDR) RuleType() C.RuleType {
 func (i *IPCIDR) Match(metadata *C.Metadata) bool {
 	ip := metadata.DstIP
 	if i.isSourceIP {
+		ruleip := i.ipnet.IP.String()
+		if metadata.SrcIP.To4() == nil && strings.HasPrefix(ruleip, "::") {
+			return strings.HasSuffix(metadata.SrcIP.String(), ruleip)
+		}
 		ip = metadata.SrcIP
 	}
 	return ip != nil && i.ipnet.Contains(ip)


### PR DESCRIPTION
前景提要 https://github.com/Dreamacro/clash/discussions/1327

在可以禁止设备使用临时 IP 的情况下，获得的 IP 后缀可以变的固定，但是由于前缀不固定，所以添加了一个特殊的 CIDR，可以只匹配后缀

规则如下：
- SRC-IP-CIDR,::ca1/128,DIRECT

如果被分配的 IP 是 240e:xx:xx:xx::ca1，则会匹配到此规则


time="2021-04-02T23:43:34+08:00" level=info msg="[TCP] [240e:xx:xx:xx::ca1]:59754 --> 2604:90:1:1::69 match SrcIPCIDR(::ca1/128) using DIRECT"
