### PR TITLE
feat: support ip6tables ip syntax

### DIFF
--- a/rules/ipcidr.go
+++ b/rules/ipcidr.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"net"
+	"strings"
 
 	C "github.com/Dreamacro/clash/constant"
 )
@@ -54,8 +55,78 @@ func (i *IPCIDR) ShouldResolveIP() bool {
 	return !i.noResolveIP
 }
 
+const big = 0xFFFFFF
+
+func dtoi(s string) (n int, i int, ok bool) {
+	n = 0
+	for i = 0; i < len(s) && '0' <= s[i] && s[i] <= '9'; i++ {
+		n = n*10 + int(s[i]-'0')
+		if n >= big {
+			return big, i, false
+		}
+	}
+	if i == 0 {
+		return 0, 0, false
+	}
+	return n, i, true
+}
+
+func CIDRMask(ones, bits int, inver bool) net.IPMask {
+	if bits != 8*net.IPv4len && bits != 8*net.IPv6len {
+		return nil
+	}
+	if ones < 0 || ones > bits {
+		return nil
+	}
+	l := bits / 8
+	m := make(net.IPMask, l)
+	n := uint(ones)
+
+	u := byte(0xff)
+	if inver {
+		u = byte(0x00)
+	}
+	for i := 0; i < l; i++ {
+		if n >= 8 {
+			m[i] = u
+			n -= 8
+			continue
+		}
+		m[i] = ^byte(u >> n)
+		n = 0
+	}
+	return m
+}
+
+func ParseCIDR(s string) (net.IP, *net.IPNet, error) {
+	i := strings.IndexByte(s, '/')
+	if i < 0 {
+		return nil, nil, &net.ParseError{Type: "CIDR address", Text: s}
+	}
+	addr, mask := s[:i], s[i+1:]
+	inver := false
+	if strings.HasPrefix(mask, "-") {
+		inver = true
+		mask = mask[1:]
+	}
+	iplen := net.IPv4len
+	ip := net.ParseIP(addr)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case ':':
+			iplen = net.IPv6len
+		}
+	}
+	n, i, ok := dtoi(mask)
+	if ip == nil || !ok || i != len(mask) || n < 0 || n > 8*iplen {
+		return nil, nil, &net.ParseError{Type: "CIDR address", Text: s}
+	}
+	m := CIDRMask(n, 8*iplen, inver)
+	return ip, &net.IPNet{IP: ip.Mask(m), Mask: m}, nil
+}
+
 func NewIPCIDR(s string, adapter string, opts ...IPCIDROption) (*IPCIDR, error) {
-	_, ipnet, err := net.ParseCIDR(s)
+	_, ipnet, err := ParseCIDR(s)
 	if err != nil {
 		return nil, errPayload
 	}


### PR DESCRIPTION
基于 https://github.com/Dreamacro/clash/pull/1329 的实现并不合理，不符合 CIDR 的定义，这里换了一种实现，参考了 ip6tables 的写法

::55c/-112 会转成如下规则，忽略前 112 位

```
-A zone_wan_forward -d ::55c/::ffff -p tcp -m comment --comment "!fw3: @rule[10]" -j zone_lan_dest_ACCEPT
-A zone_wan_forward -d ::55c/::ffff -p udp -m comment --comment "!fw3: @rule[10]" -j zone_lan_dest_ACCEPT
```
OpenWrt 对接 ip6tables 的实现在这里 https://git.openwrt.org/?p=project/firewall3.git;a=blob;f=utils.c;hb=HEAD#l831

算作一个 prototype 吧，重写了两个标准库的方法

配置
```
- SRC-IP-CIDR,240e:xxx:xxx:c940::b001/-112,DIRECT
```

效果 

```
time="2021-04-04T17:18:03+08:00" level=info msg="[TCP] [240e:xxx:xxx:c940::b001]:41917 --> 2604:90:1:1::69 match SrcIPCIDR(::b001/0000000000000000000000000000ffff) using DIRECT"
```