### PR TITLE
feat: add protocol TCP/UDP rule，optimize matching policy，set udp to true by default

### DIFF
--- a/adapters/outbound/parser.go
+++ b/adapters/outbound/parser.go
@@ -20,21 +20,27 @@ func ParseProxy(mapping map[string]interface{}) (C.Proxy, error) {
 	)
 	switch proxyType {
 	case "ss":
-		ssOption := &ShadowSocksOption{}
+		ssOption := &ShadowSocksOption{
+			UDP: true,
+		}
 		err = decoder.Decode(mapping, ssOption)
 		if err != nil {
 			break
 		}
 		proxy, err = NewShadowSocks(*ssOption)
 	case "ssr":
-		ssrOption := &ShadowSocksROption{}
+		ssrOption := &ShadowSocksROption{
+			UDP: true,
+		}
 		err = decoder.Decode(mapping, ssrOption)
 		if err != nil {
 			break
 		}
 		proxy, err = NewShadowSocksR(*ssrOption)
 	case "socks5":
-		socksOption := &Socks5Option{}
+		socksOption := &Socks5Option{
+			UDP: true,
+		}
 		err = decoder.Decode(mapping, socksOption)
 		if err != nil {
 			break
@@ -49,6 +55,7 @@ func ParseProxy(mapping map[string]interface{}) (C.Proxy, error) {
 		proxy = NewHttp(*httpOption)
 	case "vmess":
 		vmessOption := &VmessOption{
+			UDP: true,
 			HTTPOpts: HTTPOptions{
 				Method: "GET",
 				Path:   []string{"/"},
@@ -67,7 +74,9 @@ func ParseProxy(mapping map[string]interface{}) (C.Proxy, error) {
 		}
 		proxy, err = NewSnell(*snellOption)
 	case "trojan":
-		trojanOption := &TrojanOption{}
+		trojanOption := &TrojanOption{
+			UDP: true,
+		}
 		err = decoder.Decode(mapping, trojanOption)
 		if err != nil {
 			break

--- a/config/config.go
+++ b/config/config.go
@@ -376,40 +376,16 @@ func parseRules(cfg *RawConfig, proxies map[string]C.Proxy) ([]C.Rule, error) {
 
 	// parse rules
 	for idx, line := range rulesConfig {
-		rule := trimArr(strings.Split(line, ","))
-		var (
-			payload string
-			target  string
-			params  = []string{}
-		)
 
-		switch l := len(rule); {
-		case l == 2:
-			target = rule[1]
-		case l == 3:
-			payload = rule[1]
-			target = rule[2]
-		case l >= 4:
-			payload = rule[1]
-			target = rule[2]
-			params = rule[3:]
-		default:
-			return nil, fmt.Errorf("rules[%d] [%s] error: format invalid", idx, line)
-		}
-
-		if _, ok := proxies[target]; !ok {
-			return nil, fmt.Errorf("rules[%d] [%s] error: proxy [%s] not found", idx, line, target)
-		}
-
-		rule = trimArr(rule)
-		params = trimArr(params)
-
-		parsed, parseErr := R.ParseRule(rule[0], payload, target, params)
+		rule, parseErr := R.ParseRule(line)
+		target := rule.Adapter()
 		if parseErr != nil {
 			return nil, fmt.Errorf("rules[%d] [%s] error: %s", idx, line, parseErr.Error())
 		}
-
-		rules = append(rules, parsed)
+		if _, ok := proxies[target]; !ok {
+			return nil, fmt.Errorf("rules[%d] [%s] error: proxy [%s] not found", idx, line, target)
+		}
+		rules = append(rules, rule)
 	}
 
 	return rules, nil

--- a/config/utils.go
+++ b/config/utils.go
@@ -2,18 +2,10 @@ package config
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Dreamacro/clash/adapters/outboundgroup"
 	"github.com/Dreamacro/clash/common/structure"
 )
-
-func trimArr(arr []string) (r []string) {
-	for _, e := range arr {
-		r = append(r, strings.Trim(e, " "))
-	}
-	return
-}
 
 // Check if ProxyGroups form DAG(Directed Acyclic Graph), and sort all ProxyGroups by dependency order.
 // Meanwhile, record the original index in the config file.

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -2,7 +2,8 @@ package constant
 
 // Rule Type
 const (
-	Domain RuleType = iota
+	Base RuleType = iota
+	Domain
 	DomainSuffix
 	DomainKeyword
 	GEOIP
@@ -19,6 +20,8 @@ type RuleType int
 
 func (rt RuleType) String() string {
 	switch rt {
+	case Base:
+		return "Base"
 	case Domain:
 		return "Domain"
 	case DomainSuffix:

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -8,6 +8,7 @@ const (
 	GEOIP
 	IPCIDR
 	SrcIPCIDR
+	Proto
 	SrcPort
 	DstPort
 	Process
@@ -30,6 +31,8 @@ func (rt RuleType) String() string {
 		return "IPCIDR"
 	case SrcIPCIDR:
 		return "SrcIPCIDR"
+	case Proto:
+		return "Proto"
 	case SrcPort:
 		return "SrcPort"
 	case DstPort:

--- a/rules/base.go
+++ b/rules/base.go
@@ -24,9 +24,10 @@ func HasNoResolve(params []string) bool {
 }
 
 type Base struct {
-	units   []C.Rule
-	params  []string
-	adapter string
+	units    []C.Rule
+	inverses []bool
+	params   []string
+	adapter  string
 }
 
 func (b *Base) RuleType() C.RuleType {
@@ -34,8 +35,8 @@ func (b *Base) RuleType() C.RuleType {
 }
 
 func (b *Base) Match(metadata *C.Metadata) bool {
-	for _, unit := range b.units {
-		if !unit.Match(metadata) {
+	for i, unit := range b.units {
+		if !unit.Match(metadata) && !b.inverses[i] {
 			return false
 		}
 	}
@@ -43,8 +44,13 @@ func (b *Base) Match(metadata *C.Metadata) bool {
 }
 func (b *Base) Payload() string {
 	s := []string{}
-	for _, unit := range b.units {
-		s = append(s, fmt.Sprintf("%s(%s)", unit.RuleType(), unit.Payload()))
+	for i, unit := range b.units {
+		if b.inverses[i] {
+			s = append(s, fmt.Sprintf("%s(not %s)", unit.RuleType(), unit.Payload()))
+		} else {
+			s = append(s, fmt.Sprintf("%s(%s)", unit.RuleType(), unit.Payload()))
+		}
+
 	}
 	p := strings.Join(s, " ")
 	return p
@@ -65,12 +71,4 @@ func (b *Base) ShouldResolveIP() bool {
 
 func (b *Base) Adapter() string {
 	return b.adapter
-}
-
-func NewBaseRule(units []C.Rule, adapter string, params []string) *Base {
-	return &Base{
-		units:   units,
-		adapter: adapter,
-		params:  params,
-	}
 }

--- a/rules/base.go
+++ b/rules/base.go
@@ -2,12 +2,16 @@ package rules
 
 import (
 	"errors"
+	"fmt"
+	"strings"
+
+	C "github.com/Dreamacro/clash/constant"
 )
 
 var (
 	errPayload = errors.New("payload error")
-
-	noResolve = "no-resolve"
+	errNotRule = errors.New("not a rule")
+	noResolve  = "no-resolve"
 )
 
 func HasNoResolve(params []string) bool {
@@ -17,4 +21,56 @@ func HasNoResolve(params []string) bool {
 		}
 	}
 	return false
+}
+
+type Base struct {
+	units   []C.Rule
+	params  []string
+	adapter string
+}
+
+func (b *Base) RuleType() C.RuleType {
+	return C.Base
+}
+
+func (b *Base) Match(metadata *C.Metadata) bool {
+	for _, unit := range b.units {
+		if !unit.Match(metadata) {
+			return false
+		}
+	}
+	return true
+}
+func (b *Base) Payload() string {
+	s := []string{}
+	for _, unit := range b.units {
+		s = append(s, fmt.Sprintf("%s(%s)", unit.RuleType(), unit.Payload()))
+	}
+	p := strings.Join(s, " ")
+	return p
+}
+
+func (b *Base) ShouldResolveIP() bool {
+	if HasNoResolve(b.params) {
+		return false
+	}
+	for _, unit := range b.units {
+		if unit.ShouldResolveIP() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (b *Base) Adapter() string {
+	return b.adapter
+}
+
+func NewBaseRule(units []C.Rule, adapter string, params []string) *Base {
+	return &Base{
+		units:   units,
+		adapter: adapter,
+		params:  params,
+	}
 }

--- a/rules/parser.go
+++ b/rules/parser.go
@@ -27,6 +27,8 @@ func ParseRule(tp, payload, target string, params []string) (C.Rule, error) {
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRNoResolve(noResolve))
 	case "SRC-IP-CIDR":
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRSourceIP(true), WithIPCIDRNoResolve(true))
+	case "PROTO":
+		parsed,parseErr = NewProto(payload,target)
 	case "SRC-PORT":
 		parsed, parseErr = NewPort(payload, target, true)
 	case "DST-PORT":

--- a/rules/parser.go
+++ b/rules/parser.go
@@ -1,12 +1,13 @@
 package rules
 
 import (
-	"fmt"
+	"errors"
+	"strings"
 
 	C "github.com/Dreamacro/clash/constant"
 )
 
-func ParseRule(tp, payload, target string, params []string) (C.Rule, error) {
+func ParseUnitRule(tp, payload, target string) (C.Rule, error) {
 	var (
 		parseErr error
 		parsed   C.Rule
@@ -20,26 +21,59 @@ func ParseRule(tp, payload, target string, params []string) (C.Rule, error) {
 	case "DOMAIN-KEYWORD":
 		parsed = NewDomainKeyword(payload, target)
 	case "GEOIP":
-		noResolve := HasNoResolve(params)
-		parsed = NewGEOIP(payload, target, noResolve)
+		parsed = NewGEOIP(payload, target, false)
 	case "IP-CIDR", "IP-CIDR6":
-		noResolve := HasNoResolve(params)
-		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRNoResolve(noResolve))
+		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRNoResolve(false))
 	case "SRC-IP-CIDR":
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRSourceIP(true), WithIPCIDRNoResolve(true))
 	case "PROTO":
-		parsed,parseErr = NewProto(payload,target)
+		parsed, parseErr = NewProto(payload, target)
 	case "SRC-PORT":
 		parsed, parseErr = NewPort(payload, target, true)
 	case "DST-PORT":
 		parsed, parseErr = NewPort(payload, target, false)
 	case "PROCESS-NAME":
 		parsed, parseErr = NewProcess(payload, target)
-	case "MATCH":
-		parsed = NewMatch(target)
 	default:
-		parseErr = fmt.Errorf("unsupported rule type %s", tp)
+		return nil, errNotRule
 	}
 
 	return parsed, parseErr
+}
+
+func ParseRule(rule string) (C.Rule, error) {
+	units := []C.Rule{}
+	tokenList := trimArr(strings.Split(rule, ","))
+
+	if tokenList[0] == "MATCH" {
+		return NewMatch(tokenList[1]), nil
+	}
+
+	i := 0
+	for i < len(tokenList)-1 {
+		unit, err := ParseUnitRule(tokenList[i], tokenList[i+1], "DUMMY")
+		if err == nil {
+			units = append(units, unit)
+			i += 2
+		} else if !errors.Is(err, errNotRule) {
+			return nil, err
+		} else {
+			break
+		}
+	}
+	target := tokenList[i]
+	var params []string
+	if len(tokenList[i:]) > 1 {
+		params = tokenList[i+1:]
+	}
+	baseRule := NewBaseRule(units, target, params)
+
+	return baseRule, nil
+}
+
+func trimArr(arr []string) (r []string) {
+	for _, e := range arr {
+		r = append(r, strings.Trim(e, " "))
+	}
+	return
 }

--- a/rules/proto.go
+++ b/rules/proto.go
@@ -1,0 +1,46 @@
+package rules
+
+import (
+	C "github.com/Dreamacro/clash/constant"
+)
+
+type Proto struct {
+	adapter string
+	network C.NetWork
+}
+
+func (p *Proto) RuleType() C.RuleType {
+	return C.Proto
+}
+
+func (p *Proto) Match(metadata *C.Metadata) bool {
+	return metadata.NetWork == p.network
+}
+
+func (p *Proto) Adapter() string {
+	return p.adapter
+}
+
+func (p *Proto) Payload() string {
+	return p.network.String()
+}
+
+func (p *Proto) ShouldResolveIP() bool {
+	return false
+}
+
+func NewProto(s, adapter string) (*Proto, error) {
+	var network C.NetWork
+	switch s {
+	case "tcp":
+		network = C.TCP
+	case "udp":
+		network = C.UDP
+	default:
+		return nil, errPayload
+	}
+	return &Proto{
+		network: network,
+		adapter: adapter,
+	}, nil
+}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -234,7 +234,7 @@ func handleUDPConn(packet *inbound.PacketAdapter) {
 		case mode == Direct:
 			log.Infoln("[UDP] %s --> %v using DIRECT", metadata.SourceAddress(), metadata.String())
 		default:
-			log.Infoln("[UDP] %s --> %v doesn't match any rule using DIRECT", metadata.SourceAddress(), metadata.String())
+			log.Infoln("[UDP] %s --> %v doesn't match any rule using REJECT", metadata.SourceAddress(), metadata.String())
 		}
 
 		go handleUDPToLocal(packet.UDPPacket, pc, key, fAddr)
@@ -284,7 +284,7 @@ func handleTCPConn(ctx C.ConnContext) {
 	case mode == Direct:
 		log.Infoln("[TCP] %s --> %v using DIRECT", metadata.SourceAddress(), metadata.String())
 	default:
-		log.Infoln("[TCP] %s --> %v doesn't match any rule using DIRECT", metadata.SourceAddress(), metadata.String())
+		log.Infoln("[TCP] %s --> %v doesn't match any rule using REJECT", metadata.SourceAddress(), metadata.String())
 	}
 
 	switch c := ctx.(type) {
@@ -329,13 +329,8 @@ func match(metadata *C.Metadata) (C.Proxy, C.Rule, error) {
 				continue
 			}
 
-			if metadata.NetWork == C.UDP && !adapter.SupportUDP() {
-				log.Debugln("%v UDP is not supported", adapter.Name())
-				continue
-			}
 			return adapter, rule, nil
 		}
 	}
-
-	return proxies["DIRECT"], nil, nil
+	return proxies["REJECT"], nil, nil
 }


### PR DESCRIPTION

* 添加了新的规则`PROTO`用于匹配协议类型(tcp|udp)\
示例:
```yaml
rules:
- PROTO,udp,game
- PROTO,tcp,auto
- MATCH,auto
```
* 当前匹配规则时对UDP的处理不符合用户预期，`MATCH` 按照语义应该是在最后定义其他规则全部无法匹配到的默认行为，不应该存在例外，当用户配置了`MATCH` 后仍然看到 `doesn't match any rule using DIRECT` 是非常困惑的。如 #934 #811
* 即使真的无法匹配到规则，默认行为也应该回退到直接中断而不是直连，没有什么软件在配置完代理以后会因为代理不通而回退到直接连接。很多[VPN服务商甚至以提供在VPN断线后终止所有网络连接为卖点](https://nordvpn.com/features/kill-switch-technique/)。
* UDP作为互联网的基础协议，大多数代理协议都提供支持，且目前QUIC/http3等越发普及，应该在未指定时默认启用。当然考虑到有些代理服务商出于版权等因素禁用UDP，但这应该是opt-out的，而不是需要主动启用。
* 如果因为规则选择的节点不支持UDP导致无法连接怎么办？在`MATCH` 前面加一条`PROTO,udp`并指定到支持UDP的服务器(组)即可。


