### PR TITLE
fix vmess aead writer udp issue

### DIFF
--- a/component/vmess/aead.go
+++ b/component/vmess/aead.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"sync"
 
 	"github.com/Dreamacro/clash/common/pool"
 )
@@ -15,6 +16,8 @@ type aeadWriter struct {
 	nonce [32]byte
 	count uint16
 	iv    []byte
+
+	writeLock sync.Mutex
 }
 
 func newAEADWriter(w io.Writer, aead cipher.AEAD, iv []byte) *aeadWriter {
@@ -22,8 +25,12 @@ func newAEADWriter(w io.Writer, aead cipher.AEAD, iv []byte) *aeadWriter {
 }
 
 func (w *aeadWriter) Write(b []byte) (n int, err error) {
+	w.writeLock.Lock()
 	buf := pool.Get(pool.RelayBufferSize)
-	defer pool.Put(buf)
+	defer func() {
+		w.writeLock.Unlock()
+		pool.Put(buf)
+	}()
 	length := len(b)
 	for {
 		if length == 0 {


### PR DESCRIPTION
# 客户端
Android Clash
# 问题描述
使用安卓 clash 进行 WhatsApp 通话时，v2ray / xray 服务端经常会出现数据包解密出错的情况，服务端默认行为是丢弃此包，不断开连接，所以这个问题可能很久都没人发现。

使用基于 v2ray / xray 或其它实现的客户端暂时没有发现此问题。

# 问题排查
通过 debug 服务端，发现 clash 客户端发来的包的顺序有时候是错乱的，导致当前的计数 count 无法解密当前收到的数据包。vmess 协议中，若数据流使用 aead 加密，每个数据包都会使用一个自增的 count 作为 iv 的一部分进行数据包加密，所以必须要确保数据包的顺序是严格按照 count 自增的顺序发送。

通过阅读 clash 内核的代码，发现 clash 会启动多个 goroutine 进行处理 udp 数据包：
https://github.com/Dreamacro/clash/blob/baf03b81e36e3c5d8b9a370ebb82dd2b25b4a58d/tunnel/tunnel.go#L107

这就直接导致了 aeadWriter 的 Write 函数可能会被并发调用，进而引发数据包错乱的问题：
https://github.com/Dreamacro/clash/blob/baf03b81e36e3c5d8b9a370ebb82dd2b25b4a58d/component/vmess/aead.go#L24

经测试，在 Write 函数中加入锁之后，数据包的顺序不再错乱了。

# 最后
我的 pr 是最简单粗暴的解决方案，不一定好，只是起到抛砖引玉的作用，在 clash 内核中的其它协议实现可能也存在类似的问题，我个人对 clash 内核的设计还不怎么熟悉，希望有大佬能够彻底解决这个问题。