### PR TITLE
Chore: PROCESS-NAME support freebsd 13, fix panic on unsupported platforms

### DIFF
--- a/component/process/process_freebsd_amd64.go
+++ b/component/process/process_freebsd_amd64.go
@@ -30,6 +30,10 @@ func findProcessName(network string, ip net.IP, srcPort int) (string, error) {
 		}
 	})
 
+	if defaultSearcher == nil {
+		return "", ErrPlatformNotSupport
+	}
+
 	var spath string
 	isTCP := network == TCP
 	switch network {
@@ -190,6 +194,8 @@ func newSearcher(major int) *searcher {
 			udpInpOffset: 8,
 		}
 	case 12:
+		fallthrough
+	case 13:
 		s = &searcher{
 			headSize:     64,
 			tcpItemSize:  744,


### PR DESCRIPTION
FreeBSD 13 has been released: [https://www.freebsd.org/releases/13.0R/announce](https://www.freebsd.org/releases/13.0R/announce).

Luckily the offsets stay same as 12.x

Tested on FreeBSD 12.2 & FreeBSD 13.
