### PR TITLE
Fix: io timeout when snell reuse connection

### DIFF
--- a/component/snell/pool.go
+++ b/component/snell/pool.go
@@ -3,6 +3,7 @@ package snell
 import (
 	"context"
 	"net"
+	"time"
 
 	"github.com/Dreamacro/clash/component/pool"
 
@@ -61,6 +62,7 @@ func (pc *PoolConn) Write(b []byte) (int, error) {
 }
 
 func (pc *PoolConn) Close() error {
+	pc.Snell.Conn.SetReadDeadline(time.Time{})
 	pc.pool.Put(pc.Snell)
 	return nil
 }

--- a/component/snell/pool.go
+++ b/component/snell/pool.go
@@ -62,6 +62,8 @@ func (pc *PoolConn) Write(b []byte) (int, error) {
 }
 
 func (pc *PoolConn) Close() error {
+	// clash use SetReadDeadline to break bidirectional copy between client and server.
+	// reset it before reuse connection to avoid io timeout error.
 	pc.Snell.Conn.SetReadDeadline(time.Time{})
 	pc.pool.Put(pc.Snell)
 	return nil


### PR DESCRIPTION
This bug can be reproduced using [open-snell](https://github.com/icpz/open-snell) and [hey](https://github.com/rakyll/hey).

*hey is a tiny program that sends some load to a web application.*

---

snell server listens at port 5678.

```ini
[snell-server]
listen = 0.0.0.0:5678
psk = psk
obfs = http
```

clash listens at port 9999 with a default outbound to snell server.

```yaml
port: 9999
proxies:
  - name: PROXY
    obfs-opts:
      host: docs.aws.amazon.com
      mode: http
    psk: psk
    server: 127.0.0.1
    port: 5678
    type: snell
    version: 2
rules:
  - MATCH,PROXY
```

use hey to send some http request via clash

```bash
./hey -disable-keepalive -x http://127.0.0.1:9999 https://www.qq.com
```

```
Status code distribution:
  [200]	49 responses

Error distribution:
  [124]	Get "https://www.qq.com": EOF
  [1]	Get "https://www.qq.com": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51282->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51294->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51311->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51336->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51343->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51371->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51381->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51396->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51401->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51424->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51435->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51437->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51441->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51447->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51462->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51476->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51484->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51494->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51505->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51506->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51516->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51537->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51554->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51571->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51622->127.0.0.1:9999: read: connection reset by peer
  [1]	Get "https://www.qq.com": read tcp 127.0.0.1:51623->127.0.0.1:9999: read: connection reset by peer
```