### PR TITLE
Fix: should write file if provider initialize from HTTP

### DIFF
--- a/adapters/provider/fetcher.go
+++ b/adapters/provider/fetcher.go
@@ -72,6 +72,8 @@ func (f *fetcher) Initial() (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		isLocal = false
 	}
 
 	if f.vehicle.Type() != File && !isLocal {


### PR DESCRIPTION
修正了 本地初始化失败时 回退到从远程下载文件后 不会写入文件的问题