### PR TITLE
Feature: add freebsd arm64 to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ freebsd-386:
 freebsd-amd64:
 	GOARCH=amd64 GOOS=freebsd $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
 
+freebsd-arm64:
+	GOARCH=arm64 GOOS=freebsd $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
 windows-386:
 	GOARCH=386 GOOS=windows $(GOBUILD) -o $(BINDIR)/$(NAME)-$@.exe
 


### PR DESCRIPTION
Let clash can run on Raspi with FreeBSD.