### PR TITLE
Fix: skip deleted node from url-test group

### DIFF
--- a/adapters/outboundgroup/urltest.go
+++ b/adapters/outboundgroup/urltest.go
@@ -66,7 +66,13 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 		proxies := u.proxies(touch)
 		fast := proxies[0]
 		min := fast.LastDelay()
+		fastNotExist := true
+
 		for _, proxy := range proxies[1:] {
+			if u.fastNode != nil && proxy.Name() == u.fastNode.Name() {
+				fastNotExist = false
+			}
+
 			if !proxy.Alive() {
 				continue
 			}
@@ -79,7 +85,7 @@ func (u *URLTest) fast(touch bool) C.Proxy {
 		}
 
 		// tolerance
-		if u.fastNode == nil || !u.fastNode.Alive() || u.fastNode.LastDelay() > fast.LastDelay()+u.tolerance {
+		if u.fastNode == nil || fastNotExist || !u.fastNode.Alive() || u.fastNode.LastDelay() > fast.LastDelay()+u.tolerance {
 			u.fastNode = fast
 		}
 


### PR DESCRIPTION
provider 更新时，如果之前选中的最快节点已经被移除，需要进行移除，否者可能还是会返回已经移除的节点