### PR TITLE
Fix: couldn't find ip

### DIFF
--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -154,6 +154,8 @@ func (r *Resolver) batchExchange(clients []dnsClient, m *D.Msg) (msg *D.Msg, err
 				return nil, err
 			} else if m.Rcode == D.RcodeServerFailure || m.Rcode == D.RcodeRefused {
 				return nil, errors.New("server failure")
+			} else if m.Answer == nil {
+				return nil, resolver.ErrIPNotFound
 			}
 			return m, nil
 		})


### PR DESCRIPTION
当我有多个dns时，例如：
```
dns:
  enable: true
  listen: 0.0.0.0:53
  nameserver:
    - 119.29.29.29 # default value
    - 172.16.0.199 # 自建DNS，内网域名解析
```
现有程序会逐个解析，但是只会选择其中一个结果进行返回。代码如下：
picker.Go方法
```go
if ret, err := f(); err == nil {
	p.once.Do(func() {
		p.result = ret
		if p.cancel != nil {
			p.cancel()
		}
	})
} else {
	p.errOnce.Do(func() {
		p.err = err
	})
}
```
有可能私有域名一直被`119.29.29.29`解析，但是没有任何返回无不会报错，程序就会返回如下错误：
```
WARN[0009] dial DIRECT error: couldn't find ip
```
解决方案：

通过判断dns返回结果是否为空，判断该条dns解析结果是否为空需要返回。代码如下：
```go
fast.Go(func() (interface{}, error) {
	m, err := r.ExchangeContext(ctx, m)
	if err != nil {
		return nil, err
	} else if m.Rcode == D.RcodeServerFailure || m.Rcode == D.RcodeRefused {
		return nil, errors.New("server failure")
	} else if m.Answer == nil {    // 添加的代码
		return nil, resolver.ErrIPNotFound
	}
	return m, nil
})
```