### PR TITLE
Feature: lookup domain through assigned nameserver

### DIFF
--- a/component/trie/domain.go
+++ b/component/trie/domain.go
@@ -23,7 +23,7 @@ type DomainTrie struct {
 	root *Node
 }
 
-func validAndSplitDomain(domain string) ([]string, bool) {
+func ValidAndSplitDomain(domain string) ([]string, bool) {
 	if domain != "" && domain[len(domain)-1] == '.' {
 		return nil, false
 	}
@@ -54,7 +54,7 @@ func validAndSplitDomain(domain string) ([]string, bool) {
 // 4. .example.com
 // 5. +.example.com
 func (t *DomainTrie) Insert(domain string, data interface{}) error {
-	parts, valid := validAndSplitDomain(domain)
+	parts, valid := ValidAndSplitDomain(domain)
 	if !valid {
 		return ErrInvalidDomain
 	}
@@ -91,7 +91,7 @@ func (t *DomainTrie) insert(parts []string, data interface{}) {
 // 2. wildcard domain
 // 2. dot wildcard domain
 func (t *DomainTrie) Search(domain string) *Node {
-	parts, valid := validAndSplitDomain(domain)
+	parts, valid := ValidAndSplitDomain(domain)
 	if !valid || parts[0] == "" {
 		return nil
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ type DNS struct {
 	DefaultNameserver []dns.NameServer `yaml:"default-nameserver"`
 	FakeIPRange       *fakeip.Pool
 	Hosts             *trie.DomainTrie
-	AssignNameServer  map[string]dns.NameServer
+	ResolverRule      map[string]dns.NameServer
 }
 
 // FallbackFilter config
@@ -107,7 +107,7 @@ type RawDNS struct {
 	FakeIPRange       string            `yaml:"fake-ip-range"`
 	FakeIPFilter      []string          `yaml:"fake-ip-filter"`
 	DefaultNameserver []string          `yaml:"default-nameserver"`
-	AssignNameServer  map[string]string `yaml:"assign-nameserver"`
+	ResolverRule      map[string]string `yaml:"resolver-rule"`
 }
 
 type RawFallbackFilter struct {
@@ -502,20 +502,20 @@ func parseNameServer(servers []string) ([]dns.NameServer, error) {
 	return nameservers, nil
 }
 
-func parseAssignNameServer(cfg *RawDNS) (map[string]dns.NameServer, error) {
-	assign := make(map[string]dns.NameServer)
+func parseResolverRule(cfg *RawDNS) (map[string]dns.NameServer, error) {
+	rule := make(map[string]dns.NameServer)
 
-	if len(cfg.AssignNameServer) != 0 {
-		for domain, server := range cfg.AssignNameServer {
+	if len(cfg.ResolverRule) != 0 {
+		for domain, server := range cfg.ResolverRule {
 			nameservers, err := parseNameServer([]string{server})
 			if err != nil {
 				return nil, err
 			}
-			assign[domain] = nameservers[0]
+			rule[domain] = nameservers[0]
 		}
 	}
 
-	return assign, nil
+	return rule, nil
 }
 
 func parseFallbackIPCIDR(ips []string) ([]*net.IPNet, error) {
@@ -555,7 +555,7 @@ func parseDNS(cfg RawDNS, hosts *trie.DomainTrie) (*DNS, error) {
 		return nil, err
 	}
 
-	if dnsCfg.AssignNameServer, err = parseAssignNameServer(&cfg); err != nil {
+	if dnsCfg.ResolverRule, err = parseResolverRule(&cfg); err != nil {
 		return nil, err
 	}
 

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -132,8 +132,7 @@ func (r *Resolver) exchangeWithoutCache(m *D.Msg) (msg *D.Msg, err error) {
 			return r.ipExchange(m)
 		}
 
-		matched := r.matchResolverRule(m)
-		if len(matched) != 0 {
+		if matched := r.matchResolverRule(m); len(matched) != 0 {
 			return r.batchExchange(matched, m)
 		}
 		return r.batchExchange(r.main, m)
@@ -180,12 +179,12 @@ func (r *Resolver) batchExchange(clients []dnsClient, m *D.Msg) (msg *D.Msg, err
 func (r *Resolver) matchResolverRule(m *D.Msg) []dnsClient {
 	domain := r.msgToDomain(m)
 	if domain == "" {
-		return []dnsClient{}
+		return nil
 	}
 
-	record := r.rule.Search(strings.TrimRight(domain, "."))
+	record := r.rule.Search(domain)
 	if record == nil {
-		return []dnsClient{}
+		return nil
 	}
 
 	return record.Data.([]dnsClient)
@@ -213,8 +212,7 @@ func (r *Resolver) shouldOnlyQueryFallback(m *D.Msg) bool {
 
 func (r *Resolver) ipExchange(m *D.Msg) (msg *D.Msg, err error) {
 
-	matched := r.matchResolverRule(m)
-	if len(matched) != 0 {
+	if matched := r.matchResolverRule(m); len(matched) != 0 {
 		res := <-r.asyncExchange(matched, m)
 		return res.Msg, res.Error
 	}

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -177,6 +177,10 @@ func (r *Resolver) batchExchange(clients []dnsClient, m *D.Msg) (msg *D.Msg, err
 }
 
 func (r *Resolver) matchPolicy(m *D.Msg) []dnsClient {
+	if r.policy == nil {
+		return nil
+	}
+
 	domain := r.msgToDomain(m)
 	if domain == "" {
 		return nil
@@ -336,8 +340,8 @@ func NewResolver(config Config) *Resolver {
 		r.fallback = transform(config.Fallback, defaultResolver)
 	}
 
-	r.policy = trie.New()
 	if len(config.Policy) != 0 {
+		r.policy = trie.New()
 		for domain, nameserver := range config.Policy {
 			r.policy.Insert(domain, transform([]NameServer{nameserver}, defaultResolver))
 		}

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -128,7 +128,7 @@ func updateDNS(c *config.DNS) {
 			Domain: c.FallbackFilter.Domain,
 		},
 		Default: c.DefaultNameserver,
-		Rule:    c.ResolverRule,
+		Policy:  c.NameServerPolicy,
 	}
 
 	r := dns.NewResolver(cfg)

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -128,7 +128,7 @@ func updateDNS(c *config.DNS) {
 			Domain: c.FallbackFilter.Domain,
 		},
 		Default: c.DefaultNameserver,
-		Assign:  c.AssignNameServer,
+		Rule:    c.ResolverRule,
 	}
 
 	r := dns.NewResolver(cfg)

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -128,6 +128,7 @@ func updateDNS(c *config.DNS) {
 			Domain: c.FallbackFilter.Domain,
 		},
 		Default: c.DefaultNameserver,
+		Assign:  c.AssignNameServer,
 	}
 
 	r := dns.NewResolver(cfg)


### PR DESCRIPTION
Sometimes we need clash lookup domains via specific nameservers. Here is an example configuration:
```yaml
dns:
  enable: true
  listen: '0.0.0.0:53'
  assign-nameserver:
    'www.baidu.com': '114.114.114.114'
    '+.internal.crop.com': '10.0.0.1'
```

This feature may resolve issues like https://github.com/Dreamacro/clash/issues/1376 .

It seems that we need a more appropriated term here, instead of `assign-nameserver`.