### PR TITLE
reload配置时path为空则用默认值

### DIFF
--- a/hub/route/configs.go
+++ b/hub/route/configs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Dreamacro/clash/component/resolver"
 	"github.com/Dreamacro/clash/config"
+	"github.com/Dreamacro/clash/constant"
 	"github.com/Dreamacro/clash/hub/executor"
 	P "github.com/Dreamacro/clash/listener"
 	"github.com/Dreamacro/clash/log"
@@ -116,6 +117,9 @@ func updateConfigs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
+		if req.Path == "" {
+			req.Path = constant.Path.Config()
+		}
 		if !filepath.IsAbs(req.Path) {
 			render.Status(r, http.StatusBadRequest)
 			render.JSON(w, r, newError("path is not a absolute path"))


### PR DESCRIPTION
让reload从curl触发时更简单一些，reload时往往不关心之前配置文件放在哪里，只要直接使用启动时指定的配置文件就可以了。
e.g. `curl -v -X PUT -d '{}' 'http://127.0.0.1:4413/configs'`