### PR TITLE
Fix: enable DNS message compression

### DIFF
--- a/dns/server.go
+++ b/dns/server.go
@@ -30,6 +30,7 @@ func (s *Server) ServeDNS(w D.ResponseWriter, r *D.Msg) {
 		D.HandleFailed(w, r)
 		return
 	}
+	msg.Compress = true
 	w.WriteMsg(msg)
 }
 


### PR DESCRIPTION
大部分公共DNS服务器都启用了DNS域名压缩，而 miekg/dns 默认没有启用压缩，从而导致转发的DNS包体积发生膨胀。
该问题会导致某些客户端在解析含有大量CNAME记录的域名时出现问题。（例如用 Go 默认的 resolver 解析 `pcqp03pf-my.sharepoint.com`）