### PR TITLE
Add process name into metadata.

### DIFF
--- a/adapter/inbound/http.go
+++ b/adapter/inbound/http.go
@@ -17,5 +17,6 @@ func NewHTTP(target string, source net.Addr, conn net.Conn) *context.ConnContext
 		metadata.SrcIP = ip
 		metadata.SrcPort = port
 	}
+	metadata.ReadProcessName()
 	return context.NewConnContext(conn, metadata)
 }

--- a/adapter/inbound/https.go
+++ b/adapter/inbound/https.go
@@ -16,5 +16,6 @@ func NewHTTPS(request *http.Request, conn net.Conn) *context.ConnContext {
 		metadata.SrcIP = ip
 		metadata.SrcPort = port
 	}
+	metadata.ReadProcessName()
 	return context.NewConnContext(conn, metadata)
 }

--- a/adapter/inbound/packet.go
+++ b/adapter/inbound/packet.go
@@ -26,6 +26,7 @@ func NewPacket(target socks5.Addr, packet C.UDPPacket, source C.Type) *PacketAda
 		metadata.SrcPort = port
 	}
 
+	metadata.ReadProcessName()
 	return &PacketAdapter{
 		UDPPacket: packet,
 		metadata:  metadata,

--- a/adapter/inbound/socket.go
+++ b/adapter/inbound/socket.go
@@ -18,5 +18,6 @@ func NewSocket(target socks5.Addr, conn net.Conn, source C.Type) *context.ConnCo
 		metadata.SrcPort = port
 	}
 
+	metadata.ReadProcessName()
 	return context.NewConnContext(conn, metadata)
 }

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -75,7 +75,7 @@ type Metadata struct {
 	DstPort  string  `json:"destinationPort"`
 	AddrType int     `json:"-"`
 	Host     string  `json:"host"`
-	Proc     string  `json:"process"`
+	Proc     string  `json:"processName"`
 }
 
 func (m *Metadata) RemoteAddress() string {
@@ -121,7 +121,9 @@ func (m *Metadata) ReadProcessName() {
 	if !hit {
 		srcPort, err := strconv.Atoi(m.SrcPort)
 		if err != nil {
-			processCache.Set(key, "")
+			processCache.Set(key, "<CannotRead>")
+			m.Proc = "<CannotRead>"
+			return
 		}
 
 		name, err := process.FindProcessName(m.NetWork.String(), m.SrcIP, srcPort)

--- a/rule/process.go
+++ b/rule/process.go
@@ -1,17 +1,10 @@
 package rules
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
 
-	"github.com/Dreamacro/clash/common/cache"
-	"github.com/Dreamacro/clash/component/process"
 	C "github.com/Dreamacro/clash/constant"
-	"github.com/Dreamacro/clash/log"
 )
-
-var processCache = cache.NewLRUCache(cache.WithAge(2), cache.WithSize(64))
 
 type Process struct {
 	adapter string
@@ -23,26 +16,7 @@ func (ps *Process) RuleType() C.RuleType {
 }
 
 func (ps *Process) Match(metadata *C.Metadata) bool {
-	key := fmt.Sprintf("%s:%s:%s", metadata.NetWork.String(), metadata.SrcIP.String(), metadata.SrcPort)
-	cached, hit := processCache.Get(key)
-	if !hit {
-		srcPort, err := strconv.Atoi(metadata.SrcPort)
-		if err != nil {
-			processCache.Set(key, "")
-			return false
-		}
-
-		name, err := process.FindProcessName(metadata.NetWork.String(), metadata.SrcIP, srcPort)
-		if err != nil {
-			log.Debugln("[Rule] find process name %s error: %s", C.Process.String(), err.Error())
-		}
-
-		processCache.Set(key, name)
-
-		cached = name
-	}
-
-	return strings.EqualFold(cached.(string), ps.process)
+	return strings.EqualFold(metadata.Proc, ps.process)
 }
 
 func (ps *Process) Adapter() string {


### PR DESCRIPTION
This is related to discusion https://github.com/Dreamacro/clash/discussions/1485.

The change will query process name for every connections.
This is slightly different from old behavior: only query process name when the program need to decide whether a connection match a PROCESS-NAME rule.

The old behavior is reasonable, if we assume the process name is only needed for matching the rule.
However, the information of process name could be useful in many other circumstances.
Scenario 1: A user wish to check the name of program that she is using, so as to set corresponding rule.
This might not be straightforward because: 1. the program name is not always same as application name shown in Task Manager. 2. An application could delegate the network function to certain other program, so the rule based on original program might not work.
Scenario 2: A user wish to check how many connection comes out of an application. 
This might deviate from the original goal of clash. However, this indeed requires the capability to capture the traffic of an application (even when it doesn't provide a native proxy support), and clash gracefully provide this functionality.

All above applications require collaboration from other software. I will show an example leveraging this PR in ClashX in a short time.

 