### PR TITLE
[Feature] support xray's ws-0rtt path scheme

### DIFF
--- a/transport/vmess/websocket.go
+++ b/transport/vmess/websocket.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -305,6 +306,18 @@ func streamWebsocketConn(conn net.Conn, c *WebsocketConfig, earlyData *bytes.Buf
 }
 
 func StreamWebsocketConn(conn net.Conn, c *WebsocketConfig) (net.Conn, error) {
+	if u, err := url.Parse(c.Path); err == nil {
+		if q := u.Query(); q.Get("ed") != "" {
+			if ed, err := strconv.Atoi(q.Get("ed")); err == nil {
+				c.MaxEarlyData = ed
+				c.EarlyDataHeaderName = "Sec-WebSocket-Protocol"
+				q.Del("ed")
+				u.RawQuery = q.Encode()
+				c.Path = u.String()
+			}
+		}
+	}
+
 	if c.MaxEarlyData > 0 {
 		return streamWebsocketWithEarlyDataConn(conn, c)
 	}


### PR DESCRIPTION
After #1505 is merged and #1473 is closed, add xray's ws-0rtt path scheme support and can work with v2ray-plugin without addition change.
based on : [xray's websocket document](https://xtls.github.io/config/transports/websocket/)