### PR TITLE
Feature: support shuffle strategy for load-balance group

### DIFF
--- a/adapter/outboundgroup/loadbalance.go
+++ b/adapter/outboundgroup/loadbalance.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"time"
 	"net"
+	"time"
 
 	"github.com/Dreamacro/clash/adapter/outbound"
 	"github.com/Dreamacro/clash/common/murmur3"
@@ -17,6 +17,10 @@ import (
 
 	"golang.org/x/net/publicsuffix"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 type strategyFn = func(proxies []C.Proxy, metadata *C.Metadata) C.Proxy
 
@@ -121,12 +125,11 @@ func (lb *LoadBalance) SupportUDP() bool {
 }
 
 func strategyShuffle() strategyFn {
-	rand.Seed(time.Now().UnixNano())
 	maxRetry := 5
 	return func(proxies []C.Proxy, metadata *C.Metadata) C.Proxy {
 		length := len(proxies)
 		sl := shuffle(length)
-		for i := 0; i < maxRetry && i <= length; i++ {
+		for i := 0; i < maxRetry && i < length; i++ {
 			idx := sl[i]
 			proxy := proxies[idx]
 			if proxy.Alive() {


### PR DESCRIPTION
添加对负载均衡的洗牌策略的支持
使用这策略, 请求将满足平均分布的随机给所有代理.
这希望打散轮询策略的代理顺序.

用法:
```yaml
  - name: "load-balance"
    type: load-balance
    strategy: shuffle
```