### PR TITLE
Feature: route based on HTTP/Socks authentication user

### DIFF
--- a/adapter/inbound/http.go
+++ b/adapter/inbound/http.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewHTTP receive normal http request and return HTTPContext
-func NewHTTP(target socks5.Addr, source net.Addr, conn net.Conn) *context.ConnContext {
+func NewHTTP(target socks5.Addr, source net.Addr, conn net.Conn, user string) *context.ConnContext {
 	metadata := parseSocksAddr(target)
 	metadata.NetWork = C.TCP
 	metadata.Type = C.HTTP
@@ -17,5 +17,6 @@ func NewHTTP(target socks5.Addr, source net.Addr, conn net.Conn) *context.ConnCo
 		metadata.SrcIP = ip
 		metadata.SrcPort = port
 	}
+	metadata.AuthUser = user
 	return context.NewConnContext(conn, metadata)
 }

--- a/adapter/inbound/https.go
+++ b/adapter/inbound/https.go
@@ -9,12 +9,13 @@ import (
 )
 
 // NewHTTPS receive CONNECT request and return ConnContext
-func NewHTTPS(request *http.Request, conn net.Conn) *context.ConnContext {
+func NewHTTPS(request *http.Request, conn net.Conn, user string) *context.ConnContext {
 	metadata := parseHTTPAddr(request)
 	metadata.Type = C.HTTPCONNECT
 	if ip, port, err := parseAddr(conn.RemoteAddr().String()); err == nil {
 		metadata.SrcIP = ip
 		metadata.SrcPort = port
 	}
+	metadata.AuthUser = user
 	return context.NewConnContext(conn, metadata)
 }

--- a/adapter/inbound/packet.go
+++ b/adapter/inbound/packet.go
@@ -17,10 +17,11 @@ func (s *PacketAdapter) Metadata() *C.Metadata {
 }
 
 // NewPacket is PacketAdapter generator
-func NewPacket(target socks5.Addr, packet C.UDPPacket, source C.Type) *PacketAdapter {
+func NewPacket(target socks5.Addr, packet C.UDPPacket, source C.Type, user string) *PacketAdapter {
 	metadata := parseSocksAddr(target)
 	metadata.NetWork = C.UDP
 	metadata.Type = source
+	metadata.AuthUser = user
 	if ip, port, err := parseAddr(packet.LocalAddr().String()); err == nil {
 		metadata.SrcIP = ip
 		metadata.SrcPort = port

--- a/adapter/inbound/packet.go
+++ b/adapter/inbound/packet.go
@@ -21,11 +21,11 @@ func NewPacket(target socks5.Addr, packet C.UDPPacket, source C.Type, user strin
 	metadata := parseSocksAddr(target)
 	metadata.NetWork = C.UDP
 	metadata.Type = source
-	metadata.AuthUser = user
 	if ip, port, err := parseAddr(packet.LocalAddr().String()); err == nil {
 		metadata.SrcIP = ip
 		metadata.SrcPort = port
 	}
+	metadata.AuthUser = user
 
 	return &PacketAdapter{
 		UDPPacket: packet,

--- a/adapter/inbound/socket.go
+++ b/adapter/inbound/socket.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewSocket receive TCP inbound and return ConnContext
-func NewSocket(target socks5.Addr, conn net.Conn, source C.Type) *context.ConnContext {
+func NewSocket(target socks5.Addr, conn net.Conn, source C.Type, user string) *context.ConnContext {
 	metadata := parseSocksAddr(target)
 	metadata.NetWork = C.TCP
 	metadata.Type = source
@@ -17,6 +17,7 @@ func NewSocket(target socks5.Addr, conn net.Conn, source C.Type) *context.ConnCo
 		metadata.SrcIP = ip
 		metadata.SrcPort = port
 	}
+	metadata.AuthUser = user
 
 	return context.NewConnContext(conn, metadata)
 }

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -72,6 +72,7 @@ type Metadata struct {
 	AddrType int     `json:"-"`
 	Host     string  `json:"host"`
 	DNSMode  DNSMode `json:"dnsMode"`
+	AuthUser string  `json:"-"`
 }
 
 func (m *Metadata) RemoteAddress() string {

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -11,6 +11,7 @@ const (
 	SrcPort
 	DstPort
 	Process
+	AuthUser
 	MATCH
 )
 
@@ -36,6 +37,8 @@ func (rt RuleType) String() string {
 		return "DstPort"
 	case Process:
 		return "Process"
+	case AuthUser:
+		return "AuthUser"
 	case MATCH:
 		return "Match"
 	default:

--- a/listener/auth/auth.go
+++ b/listener/auth/auth.go
@@ -10,6 +10,13 @@ func Authenticator() auth.Authenticator {
 	return authenticator
 }
 
+func Users() []string {
+	if authenticator == nil {
+		return []string{}
+	}
+	return authenticator.Users()
+}
+
 func SetAuthenticator(au auth.Authenticator) {
 	authenticator = au
 }

--- a/listener/http/proxy.go
+++ b/listener/http/proxy.go
@@ -15,9 +15,14 @@ import (
 	"github.com/Dreamacro/clash/log"
 )
 
+type authCache struct {
+	success bool
+	user    string
+}
+
 func HandleConn(c net.Conn, in chan<- C.ConnContext, cache *cache.Cache) {
 	client := newClient(c.RemoteAddr(), in)
-	defer client.CloseIdleConnections()
+	defer client.client.CloseIdleConnections()
 
 	conn := N.NewBufferedConn(c)
 
@@ -35,9 +40,10 @@ func HandleConn(c net.Conn, in chan<- C.ConnContext, cache *cache.Cache) {
 		keepAlive = strings.TrimSpace(strings.ToLower(request.Header.Get("Proxy-Connection"))) == "keep-alive"
 
 		var resp *http.Response
+		var user string
 
 		if !trusted {
-			resp = authenticate(request, cache)
+			resp, user = authenticate(request, cache)
 
 			trusted = resp == nil
 		}
@@ -49,7 +55,7 @@ func HandleConn(c net.Conn, in chan<- C.ConnContext, cache *cache.Cache) {
 					break // close connection
 				}
 
-				in <- inbound.NewHTTPS(request, conn)
+				in <- inbound.NewHTTPS(request, conn, user)
 
 				return // hijack connection
 			}
@@ -67,7 +73,8 @@ func HandleConn(c net.Conn, in chan<- C.ConnContext, cache *cache.Cache) {
 			if request.URL.Scheme == "" || request.URL.Host == "" {
 				resp = responseWith(request, http.StatusBadRequest)
 			} else {
-				resp, err = client.Do(request)
+				client.user = user
+				resp, err = client.client.Do(request)
 				if err != nil {
 					resp = responseWith(request, http.StatusBadGateway)
 				}
@@ -93,30 +100,35 @@ func HandleConn(c net.Conn, in chan<- C.ConnContext, cache *cache.Cache) {
 	conn.Close()
 }
 
-func authenticate(request *http.Request, cache *cache.Cache) *http.Response {
+func authenticate(request *http.Request, cache *cache.Cache) (resp *http.Response, user string) {
 	authenticator := authStore.Authenticator()
 	if authenticator != nil {
 		credential := parseBasicProxyAuthorization(request)
 		if credential == "" {
-			resp := responseWith(request, http.StatusProxyAuthRequired)
+			resp = responseWith(request, http.StatusProxyAuthRequired)
 			resp.Header.Set("Proxy-Authenticate", "Basic")
-			return resp
+			return
 		}
 
 		var authed interface{}
 		if authed = cache.Get(credential); authed == nil {
 			user, pass, err := decodeBasicProxyAuthorization(credential)
-			authed = err == nil && authenticator.Verify(user, pass)
+			authed = &authCache{
+				success: err == nil && authenticator.Verify(user, pass),
+				user:    user,
+			}
 			cache.Put(credential, authed, time.Minute)
 		}
-		if !authed.(bool) {
+		if !authed.(*authCache).success {
 			log.Infoln("Auth failed from %s", request.RemoteAddr)
 
-			return responseWith(request, http.StatusForbidden)
+			return responseWith(request, http.StatusForbidden), ""
 		}
+		user = authed.(*authCache).user
+		return
 	}
 
-	return nil
+	return
 }
 
 func responseWith(request *http.Request, statusCode int) *http.Response {

--- a/listener/redir/tcp.go
+++ b/listener/redir/tcp.go
@@ -62,5 +62,5 @@ func handleRedir(conn net.Conn, in chan<- C.ConnContext) {
 		return
 	}
 	conn.(*net.TCPConn).SetKeepAlive(true)
-	in <- inbound.NewSocket(target, conn, C.REDIR)
+	in <- inbound.NewSocket(target, conn, C.REDIR, "")
 }

--- a/listener/socks/tcp.go
+++ b/listener/socks/tcp.go
@@ -16,6 +16,8 @@ type Listener struct {
 	listener net.Listener
 	addr     string
 	closed   bool
+
+	udpUserMap map[string]string
 }
 
 // RawAddress implements C.Listener
@@ -32,6 +34,32 @@ func (l *Listener) Address() string {
 func (l *Listener) Close() error {
 	l.closed = true
 	return l.listener.Close()
+}
+
+// SetUDPUserMap inject user to mapping for socks5 udp associate
+func (l *Listener) SetUDPUserMap(userMap map[string]*UDPListener) {
+	l.udpUserMap = make(map[string]string, len(userMap))
+	for user, lis := range userMap {
+		l.udpUserMap[user] = lis.addr
+	}
+}
+
+func (l *Listener) handleSocks(conn net.Conn, in chan<- C.ConnContext) {
+	bufConn := N.NewBufferedConn(conn)
+	head, err := bufConn.Peek(1)
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	switch head[0] {
+	case socks4.Version:
+		HandleSocks4(bufConn, in)
+	case socks5.Version:
+		HandleSocks5(bufConn, in, l.udpUserMap)
+	default:
+		conn.Close()
+	}
 }
 
 func New(addr string, in chan<- C.ConnContext) (*Listener, error) {
@@ -53,29 +81,11 @@ func New(addr string, in chan<- C.ConnContext) (*Listener, error) {
 				}
 				continue
 			}
-			go handleSocks(c, in)
+			go sl.handleSocks(c, in)
 		}
 	}()
 
 	return sl, nil
-}
-
-func handleSocks(conn net.Conn, in chan<- C.ConnContext) {
-	bufConn := N.NewBufferedConn(conn)
-	head, err := bufConn.Peek(1)
-	if err != nil {
-		conn.Close()
-		return
-	}
-
-	switch head[0] {
-	case socks4.Version:
-		HandleSocks4(bufConn, in)
-	case socks5.Version:
-		HandleSocks5(bufConn, in)
-	default:
-		conn.Close()
-	}
 }
 
 func HandleSocks4(conn net.Conn, in chan<- C.ConnContext) {
@@ -90,8 +100,8 @@ func HandleSocks4(conn net.Conn, in chan<- C.ConnContext) {
 	in <- inbound.NewSocket(socks5.ParseAddr(addr), conn, C.SOCKS4, user)
 }
 
-func HandleSocks5(conn net.Conn, in chan<- C.ConnContext) {
-	target, command, user, err := socks5.ServerHandshake(conn, authStore.Authenticator())
+func HandleSocks5(conn net.Conn, in chan<- C.ConnContext, userMapping map[string]string) {
+	target, command, user, err := socks5.ServerHandshake(conn, authStore.Authenticator(), userMapping)
 	if err != nil {
 		conn.Close()
 		return

--- a/listener/socks/tcp.go
+++ b/listener/socks/tcp.go
@@ -79,7 +79,7 @@ func handleSocks(conn net.Conn, in chan<- C.ConnContext) {
 }
 
 func HandleSocks4(conn net.Conn, in chan<- C.ConnContext) {
-	addr, _, err := socks4.ServerHandshake(conn, authStore.Authenticator())
+	addr, _, user, err := socks4.ServerHandshake(conn, authStore.Authenticator())
 	if err != nil {
 		conn.Close()
 		return
@@ -87,11 +87,11 @@ func HandleSocks4(conn net.Conn, in chan<- C.ConnContext) {
 	if c, ok := conn.(*net.TCPConn); ok {
 		c.SetKeepAlive(true)
 	}
-	in <- inbound.NewSocket(socks5.ParseAddr(addr), conn, C.SOCKS4)
+	in <- inbound.NewSocket(socks5.ParseAddr(addr), conn, C.SOCKS4, user)
 }
 
 func HandleSocks5(conn net.Conn, in chan<- C.ConnContext) {
-	target, command, err := socks5.ServerHandshake(conn, authStore.Authenticator())
+	target, command, user, err := socks5.ServerHandshake(conn, authStore.Authenticator())
 	if err != nil {
 		conn.Close()
 		return
@@ -104,5 +104,5 @@ func HandleSocks5(conn net.Conn, in chan<- C.ConnContext) {
 		io.Copy(io.Discard, conn)
 		return
 	}
-	in <- inbound.NewSocket(target, conn, C.SOCKS5)
+	in <- inbound.NewSocket(target, conn, C.SOCKS5, user)
 }

--- a/listener/tproxy/tproxy.go
+++ b/listener/tproxy/tproxy.go
@@ -33,7 +33,7 @@ func (l *Listener) Close() error {
 func (l *Listener) handleTProxy(conn net.Conn, in chan<- C.ConnContext) {
 	target := socks5.ParseAddrToSocksAddr(conn.LocalAddr())
 	conn.(*net.TCPConn).SetKeepAlive(true)
-	in <- inbound.NewSocket(target, conn, C.TPROXY)
+	in <- inbound.NewSocket(target, conn, C.TPROXY, "")
 }
 
 func New(addr string, in chan<- C.ConnContext) (*Listener, error) {

--- a/listener/tproxy/udp.go
+++ b/listener/tproxy/udp.go
@@ -85,7 +85,7 @@ func handlePacketConn(pc net.PacketConn, in chan<- *inbound.PacketAdapter, buf [
 		buf:   buf,
 	}
 	select {
-	case in <- inbound.NewPacket(target, pkt, C.TPROXY):
+	case in <- inbound.NewPacket(target, pkt, C.TPROXY, ""):
 	default:
 	}
 }

--- a/rule/auth_user.go
+++ b/rule/auth_user.go
@@ -1,0 +1,37 @@
+package rules
+
+import (
+	C "github.com/Dreamacro/clash/constant"
+)
+
+type AuthUser struct {
+	user    string
+	adapter string
+}
+
+func (au *AuthUser) RuleType() C.RuleType {
+	return C.AuthUser
+}
+
+func (au *AuthUser) Match(metadata *C.Metadata) bool {
+	return metadata.AuthUser == au.user
+}
+
+func (au *AuthUser) Adapter() string {
+	return au.adapter
+}
+
+func (au *AuthUser) Payload() string {
+	return au.user
+}
+
+func (au *AuthUser) ShouldResolveIP() bool {
+	return false
+}
+
+func NewAuthUser(user string, adapter string) *AuthUser {
+	return &AuthUser{
+		user:    user,
+		adapter: adapter,
+	}
+}

--- a/rule/parser.go
+++ b/rule/parser.go
@@ -33,6 +33,8 @@ func ParseRule(tp, payload, target string, params []string) (C.Rule, error) {
 		parsed, parseErr = NewPort(payload, target, false)
 	case "PROCESS-NAME":
 		parsed, parseErr = NewProcess(payload, target)
+	case "AUTH-USER":
+		parsed = NewAuthUser(payload, target)
 	case "MATCH":
 		parsed = NewMatch(target)
 	default:

--- a/transport/socks4/socks4.go
+++ b/transport/socks4/socks4.go
@@ -40,7 +40,7 @@ var (
 	ErrRequestUnknownCode      = errors.New("request failed with unknown code")
 )
 
-func ServerHandshake(rw io.ReadWriter, authenticator auth.Authenticator) (addr string, command Command, err error) {
+func ServerHandshake(rw io.ReadWriter, authenticator auth.Authenticator) (addr string, command Command, user string, err error) {
 	var req [8]byte
 	if _, err = io.ReadFull(rw, req[:]); err != nil {
 		return
@@ -70,6 +70,7 @@ func ServerHandshake(rw io.ReadWriter, authenticator auth.Authenticator) (addr s
 	if userID, err = readUntilNull(rw); err != nil {
 		return
 	}
+	user = string(userID)
 
 	if isReservedIP(dstIP) {
 		var target []byte
@@ -87,7 +88,7 @@ func ServerHandshake(rw io.ReadWriter, authenticator auth.Authenticator) (addr s
 	}
 
 	// SOCKS4 only support USERID auth.
-	if authenticator == nil || authenticator.Verify(string(userID), "") {
+	if authenticator == nil || authenticator.Verify(user, "") {
 		code = RequestGranted
 	} else {
 		code = RequestIdentdMismatched

--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -105,7 +105,7 @@ type User struct {
 }
 
 // ServerHandshake fast-tracks SOCKS initialization to get target address to connect on server side.
-func ServerHandshake(rw net.Conn, authenticator auth.Authenticator) (addr Addr, command Command, err error) {
+func ServerHandshake(rw net.Conn, authenticator auth.Authenticator) (addr Addr, command Command, user string, err error) {
 	// Read RFC 1928 for request and reply structure and sizes.
 	buf := make([]byte, MaxAddrLen)
 	// read VER, NMETHODS, METHODS
@@ -140,7 +140,7 @@ func ServerHandshake(rw net.Conn, authenticator auth.Authenticator) (addr Addr, 
 		if _, err = io.ReadFull(rw, authBuf[:userLen]); err != nil {
 			return
 		}
-		user := string(authBuf[:userLen])
+		user = string(authBuf[:userLen])
 
 		// Get password
 		if _, err = rw.Read(header[:1]); err != nil {

--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -117,7 +117,6 @@ func ServerHandshake(rw net.Conn, authenticator auth.Authenticator, userMapping 
 		return
 	}
 
-	var user string
 	// write VER METHOD
 	if authenticator != nil {
 		if _, err = rw.Write([]byte{5, 2}); err != nil {


### PR DESCRIPTION
### STALE WARNING
This PR was inactive for a long time. If you're looking for binaries that supports this feature, use [clash-re](https://github.com/ExcitedCodes/clash/releases)

### What?
- Stores username used to authenticate (if enabled) into metadata while connecting via socks5/http listener
- Adds a new rule `AUTH-USER` to match username stored above

### Motivation
Clash is good at routing, especially with premium scripting feature & web dashboard to switch proxies instantly.
However, it lacks the ability to integrate with front proxy softwares (e.g. Proxifier, SwitchyOmega) currently, i.e. the front proxy software can't actively tell clash "this connection should be routed to a low-latency node / big-bandwidth node". All it can do is to choose connect directly or pass the traffic to clash.

1. Initially I'm creating this feature for per-app routing using Proxifier as the front proxy handler. Before you ask, the `PROCESS-NAME` rule wasn't powerful enough IMO. For example, Proxifier allows us to match every Adobe process using this pattern:
   ```
   [Applications]
   "C:\Program Files\Adobe\*"
   "C:\Program Files (x86)\Adobe\*"
   ```
   And it would be much better than writing a long, but may not match every request (and may match traffic from other programs) `IP-CIDR` & `DOMAIN-SUFFIX` list. Of course, we can create rule like `PROCESS-NAME-REGEX` to match these. But I believe it would be better to have clash running on a single device (e.g. the gateway) in order to maintain a single set of routing rule, and being able to do per-app routing on LAN devices at the same time.

2. I also found similar feature requests that can be satisfied with this PR:
    - #629 would like to route traffic based on protocol in order to "match all requests from SwitchyOmega"
    - #1242 would like to have multiple listeners and route specified port via a proxy group
    - #1568 would like to listen to another port in order to "route using chrome plugins", which is the "front proxy software"
    I've read through the listener mechanism of Clash, it would be a massive refactor to listen on multiple ports. Issues mentioned above can be solved elegantly if we're able to route by socks5/http user, which is well supported by most front proxy softwares.

### Implementation & Considerations
- Currently I'm storing authenticated user into metadata. The consideration is if this get merged, premium scripting can be boosted greatly.
- The `AuthUser` metadata won't be send to external controllers in API... Not sure if it's really needed.
- `tproxy` / `redir`: requests will have an empty `AuthUser` field, I believe If someone really want to distinguish these traffic, they'd better use scripting.
- `socks5` UDP: Current implementation (Thanks to @fakeboboliu who helped implementing this, https://github.com/ExcitedCodes/clash/pull/1) requires a map in order to associate user with listener, so we're creating a map and listen for each user on clash start, this may cause extra port usage for those who don't want to use UDP at all.
- `socks4` behaviour: Since we're reading user id no matter authentication is enable or not, the `AUTH-USER` rule will affect socks4 requests if matching user id present, but not socks5 or http requests. Not sure if this behaviour should be "fixed".
- Authentication disabled: `AuthUser` is simply an empty string.

👆 Feel free to comment on "Not sure" parts or anything I missed, thank you!

### Have you tested this?
Sure, tested with curl, (http, https) requests sent via (socks5, socks4, http) with (authentication disabled, enabled), no problem so far. @fakeboboliu tested the UDP protocol and reported no problem: https://github.com/ExcitedCodes/clash/pull/1#issuecomment-913760505
