### PR TITLE
Fix: support leading zero padding in ip-cidr rule

### DIFF
--- a/rule/ipcidr.go
+++ b/rule/ipcidr.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"net"
+	"regexp"
 
 	C "github.com/Dreamacro/clash/constant"
 )
@@ -54,7 +55,11 @@ func (i *IPCIDR) ShouldResolveIP() bool {
 	return !i.noResolveIP
 }
 
+var purify = regexp.MustCompile(`\b0+\B`)
+
 func NewIPCIDR(s string, adapter string, opts ...IPCIDROption) (*IPCIDR, error) {
+	s = purify.ReplaceAllString(s, "")
+
 	_, ipnet, err := net.ParseCIDR(s)
 	if err != nil {
 		return nil, errPayload


### PR DESCRIPTION
This PR intend to work with IP addresses like `001.001.001.002/32` in ip-cidr rules.

The zero padding is used in [RFC 870](https://datatracker.ietf.org/doc/html/rfc870) and [RFC 790](https://datatracker.ietf.org/doc/html/rfc790). It's better to provide support for robust.

As defined of dot-decimal notation, the leading zero should not be considered as a notation of octal, so removing them will not affect.

Since there's still usage of leading zeros in real-world (e.g. some firewalls, Nintendo switch), supporting them will reduce complexity to transform rules.

The leading zeroes can also provide an option to align ip-cidr rules for beautiful.