### PR TITLE
Fix: http/https proxy authentication

### DIFF
--- a/listener/http/proxy.go
+++ b/listener/http/proxy.go
@@ -63,8 +63,8 @@ func HandleConn(c net.Conn, in chan<- C.ConnContext, cache *cache.Cache) {
 
 			request.RequestURI = ""
 
-			RemoveHopByHopHeaders(request.Header)
-			RemoveExtraHTTPHostPort(request)
+			removeHopByHopHeaders(request.Header)
+			removeExtraHTTPHostPort(request)
 
 			if request.URL.Scheme == "" || request.URL.Host == "" {
 				resp = responseWith(http.StatusBadRequest)
@@ -74,9 +74,9 @@ func HandleConn(c net.Conn, in chan<- C.ConnContext, cache *cache.Cache) {
 					resp = responseWith(http.StatusBadGateway)
 				}
 			}
-		}
 
-		RemoveHopByHopHeaders(resp.Header)
+			removeHopByHopHeaders(resp.Header)
+		}
 
 		if keepAlive {
 			resp.Header.Set("Proxy-Connection", "keep-alive")
@@ -98,7 +98,7 @@ func HandleConn(c net.Conn, in chan<- C.ConnContext, cache *cache.Cache) {
 func authenticate(request *http.Request, cache *cache.Cache) *http.Response {
 	authenticator := authStore.Authenticator()
 	if authenticator != nil {
-		credential := ParseBasicProxyAuthorization(request)
+		credential := parseBasicProxyAuthorization(request)
 		if credential == "" {
 			resp := responseWith(http.StatusProxyAuthRequired)
 			resp.Header.Set("Proxy-Authenticate", "Basic")
@@ -107,7 +107,7 @@ func authenticate(request *http.Request, cache *cache.Cache) *http.Response {
 
 		var authed interface{}
 		if authed = cache.Get(credential); authed == nil {
-			user, pass, err := DecodeBasicProxyAuthorization(credential)
+			user, pass, err := decodeBasicProxyAuthorization(credential)
 			authed = err == nil && authenticator.Verify(user, pass)
 			cache.Put(credential, authed, time.Minute)
 		}

--- a/listener/http/utils.go
+++ b/listener/http/utils.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-// RemoveHopByHopHeaders remove hop-by-hop header
-func RemoveHopByHopHeaders(header http.Header) {
+// removeHopByHopHeaders remove hop-by-hop header
+func removeHopByHopHeaders(header http.Header) {
 	// Strip hop-by-hop header based on RFC:
 	// http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1
 	// https://www.mnot.net/blog/2011/07/11/what_proxies_must_do
@@ -32,9 +32,9 @@ func RemoveHopByHopHeaders(header http.Header) {
 	}
 }
 
-// RemoveExtraHTTPHostPort remove extra host port (example.com:80 --> example.com)
+// removeExtraHTTPHostPort remove extra host port (example.com:80 --> example.com)
 // It resolves the behavior of some HTTP servers that do not handle host:80 (e.g. baidu.com)
-func RemoveExtraHTTPHostPort(req *http.Request) {
+func removeExtraHTTPHostPort(req *http.Request) {
 	host := req.Host
 	if host == "" {
 		host = req.URL.Host
@@ -48,8 +48,8 @@ func RemoveExtraHTTPHostPort(req *http.Request) {
 	req.URL.Host = host
 }
 
-// ParseBasicProxyAuthorization parse header Proxy-Authorization and return base64-encoded credential
-func ParseBasicProxyAuthorization(request *http.Request) string {
+// parseBasicProxyAuthorization parse header Proxy-Authorization and return base64-encoded credential
+func parseBasicProxyAuthorization(request *http.Request) string {
 	value := request.Header.Get("Proxy-Authorization")
 	if !strings.HasPrefix(value, "Basic ") {
 		return ""
@@ -58,8 +58,8 @@ func ParseBasicProxyAuthorization(request *http.Request) string {
 	return value[6:] // value[len("Basic "):]
 }
 
-// DecodeBasicProxyAuthorization decode base64-encoded credential
-func DecodeBasicProxyAuthorization(credential string) (string, string, error) {
+// decodeBasicProxyAuthorization decode base64-encoded credential
+func decodeBasicProxyAuthorization(credential string) (string, string, error) {
 	plain, err := base64.StdEncoding.DecodeString(credential)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Status/407
https://tools.ietf.org/html/rfc7235#section-3.2
According to above, "Proxy-Authenticate" header should not be remove when
the status is proxy authentication required.

This may fix Chrome SwitchyOmega directly use a https proxy include authentication.
Related to [1443](https://github.com/Dreamacro/clash/pull/1443) and [issuecomment-916173170](https://github.com/Dreamacro/clash/pull/1584#issuecomment-916173170)