### PR TITLE
Fix: should not trust address of http.Client

### DIFF
--- a/adapter/inbound/http.go
+++ b/adapter/inbound/http.go
@@ -9,8 +9,8 @@ import (
 )
 
 // NewHTTP receive normal http request and return HTTPContext
-func NewHTTP(target string, source net.Addr, conn net.Conn) *context.ConnContext {
-	metadata := parseSocksAddr(socks5.ParseAddr(target))
+func NewHTTP(target socks5.Addr, source net.Addr, conn net.Conn) *context.ConnContext {
+	metadata := parseSocksAddr(target)
 	metadata.NetWork = C.TCP
 	metadata.Type = C.HTTP
 	if ip, port, err := parseAddr(source.String()); err == nil {

--- a/listener/http/client.go
+++ b/listener/http/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Dreamacro/clash/adapter/inbound"
 	C "github.com/Dreamacro/clash/constant"
+	"github.com/Dreamacro/clash/transport/socks5"
 )
 
 func newClient(source net.Addr, in chan<- C.ConnContext) *http.Client {
@@ -25,9 +26,14 @@ func newClient(source net.Addr, in chan<- C.ConnContext) *http.Client {
 					return nil, errors.New("unsupported network " + network)
 				}
 
+				dstAddr := socks5.ParseAddr(address)
+				if dstAddr == nil {
+					return nil, socks5.ErrAddressNotSupported
+				}
+
 				left, right := net.Pipe()
 
-				in <- inbound.NewHTTP(address, source, right)
+				in <- inbound.NewHTTP(dstAddr, source, right)
 
 				return left, nil
 			},


### PR DESCRIPTION
应该检查 http.Client.DialContext 的入参 (