### PR TITLE
Fix: make Pure() works for all hosts from mapping pool

### DIFF
--- a/component/resolver/enhancer.go
+++ b/component/resolver/enhancer.go
@@ -11,7 +11,7 @@ type Enhancer interface {
 	MappingEnabled() bool
 	IsFakeIP(net.IP) bool
 	IsExistFakeIP(net.IP) bool
-	FindHostByIP(net.IP) (string, bool)
+	FindHostByIP(net.IP) (string, string, bool)
 }
 
 func FakeIPEnabled() bool {
@@ -46,10 +46,10 @@ func IsExistFakeIP(ip net.IP) bool {
 	return false
 }
 
-func FindHostByIP(ip net.IP) (string, bool) {
+func FindHostByIP(ip net.IP) (string, string, bool) {
 	if mapper := DefaultHostMapper; mapper != nil {
 		return mapper.FindHostByIP(ip)
 	}
 
-	return "", false
+	return "", "", false
 }

--- a/dns/enhancer.go
+++ b/dns/enhancer.go
@@ -46,20 +46,20 @@ func (h *ResolverEnhancer) IsFakeIP(ip net.IP) bool {
 	return false
 }
 
-func (h *ResolverEnhancer) FindHostByIP(ip net.IP) (string, bool) {
+func (h *ResolverEnhancer) FindHostByIP(ip net.IP) (string, string, bool) {
 	if pool := h.fakePool; pool != nil {
 		if host, existed := pool.LookBack(ip); existed {
-			return host, true
+			return host, C.DNSFakeIP.String(), true
 		}
 	}
 
 	if mapping := h.mapping; mapping != nil {
 		if host, existed := h.mapping.Get(ip.String()); existed {
-			return host.(string), true
+			return host.(string), C.DNSMapping.String(), true
 		}
 	}
 
-	return "", false
+	return "", "", false
 }
 
 func (h *ResolverEnhancer) PatchFrom(o *ResolverEnhancer) {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -129,14 +129,13 @@ func preHandleMetadata(metadata *C.Metadata) error {
 
 	// preprocess enhanced-mode metadata
 	if needLookupIP(metadata) {
-		host, exist := resolver.FindHostByIP(metadata.DstIP)
+		host, dnsMode, exist := resolver.FindHostByIP(metadata.DstIP)
 		if exist {
 			metadata.Host = host
 			metadata.AddrType = C.AtypDomainName
-			metadata.DNSMode = C.DNSMapping
+			metadata.DNSMode = C.DNSModeMapping[dnsMode]
 			if resolver.FakeIPEnabled() {
 				metadata.DstIP = nil
-				metadata.DNSMode = C.DNSFakeIP
 			} else if node := resolver.DefaultHosts.Search(host); node != nil {
 				// redir-host should lookup the hosts
 				metadata.DstIP = node.Data.(net.IP)


### PR DESCRIPTION
fakeip 会 fallback 到 mapping，但是 `metadata.Pure()` 只对模式是 redir 的 metadata 进行作业

如果确实要让所有的 redir 均按 https://github.com/Dreamacro/clash/commit/81d5da51a3b0d84ed0a6f752c3e7c02e1065bce1 工作，那这个在 fakeip 之后的 mapping 也应当被纳入 Pure 的范围

而如果要保留这个作为一个需要 legacy-redir 行为的 trick，不如提供一个配置项来的更为直接一些