### PR TITLE
Feature: local hosts in clash dns server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ type DNS struct {
 	Listen            string           `yaml:"listen"`
 	EnhancedMode      C.DNSMode        `yaml:"enhanced-mode"`
 	DefaultNameserver []dns.NameServer `yaml:"default-nameserver"`
+	LocalHosts        bool             `yaml:"local-hosts"`
 	FakeIPRange       *fakeip.Pool
 	Hosts             *trie.DomainTrie
 	NameServerPolicy  map[string]dns.NameServer
@@ -103,6 +104,7 @@ type RawDNS struct {
 	Enable            bool              `yaml:"enable"`
 	IPv6              bool              `yaml:"ipv6"`
 	UseHosts          bool              `yaml:"use-hosts"`
+	LocalHosts        bool              `yaml:"local-hosts"`
 	NameServer        []string          `yaml:"nameserver"`
 	Fallback          []string          `yaml:"fallback"`
 	FallbackFilter    RawFallbackFilter `yaml:"fallback-filter"`
@@ -173,6 +175,7 @@ func UnmarshalRawConfig(buf []byte) (*RawConfig, error) {
 		DNS: RawDNS{
 			Enable:      false,
 			UseHosts:    true,
+			LocalHosts:  false,
 			FakeIPRange: "198.18.0.1/16",
 			FallbackFilter: RawFallbackFilter{
 				GeoIP:     true,
@@ -556,6 +559,7 @@ func parseDNS(rawCfg *RawConfig, hosts *trie.DomainTrie) (*DNS, error) {
 		FallbackFilter: FallbackFilter{
 			IPCIDR: []*net.IPNet{},
 		},
+		LocalHosts: cfg.LocalHosts,
 	}
 	var err error
 	if dnsCfg.NameServer, err = parseNameServer(cfg.NameServer); err != nil {

--- a/dns/hosts.go
+++ b/dns/hosts.go
@@ -1,0 +1,77 @@
+package dns
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Dreamacro/clash/component/trie"
+)
+
+func LoadHosts() *trie.DomainTrie {
+	f, err := os.Open(hostsPath())
+	if err != nil {
+		return nil
+	}
+
+	t := trie.New()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() == true {
+		line := strings.TrimSpace(sc.Text())
+
+		// ignore comments
+		if strings.HasPrefix(line, "//") || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// ignore records with non-ascii character
+		for i := 0; i < len(line); i++ {
+			if line[i] >= utf8.RuneSelf {
+				continue
+			}
+		}
+
+		buf := bytes.NewBuffer([]byte(line))
+		namesc := bufio.NewScanner(buf)
+		namesc.Split(bufio.ScanWords)
+		var ip net.IP
+		for namesc.Scan() == true {
+			name := namesc.Text()
+
+			if ip == nil {
+				ip = net.ParseIP(name)
+				if ip == nil {
+					break
+				}
+				continue
+			}
+
+			t.Insert(name, ip)
+		}
+	}
+
+	return t
+}
+
+func hostsPath() string {
+	switch runtime.GOOS {
+	case "windows":
+		var sysRoot string
+		for _, e := range os.Environ() {
+			subs := strings.SplitN(e, "=", 2)
+			if subs[0] == "SystemRoot" && len(subs) == 2 {
+				sysRoot = subs[1]
+				break
+			}
+		}
+		return path.Join(sysRoot, "\\System32\\drivers\\etc\\hosts")
+	default:
+		return "/etc/hosts"
+	}
+}

--- a/dns/hosts.go
+++ b/dns/hosts.go
@@ -22,7 +22,7 @@ func LoadHosts() *trie.DomainTrie {
 	t := trie.New()
 
 	sc := bufio.NewScanner(f)
-	for sc.Scan() == true {
+	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
 
 		// ignore comments
@@ -41,7 +41,7 @@ func LoadHosts() *trie.DomainTrie {
 		namesc := bufio.NewScanner(buf)
 		namesc.Split(bufio.ScanWords)
 		var ip net.IP
-		for namesc.Scan() == true {
+		for namesc.Scan() {
 			name := namesc.Text()
 
 			if ip == nil {

--- a/dns/middleware.go
+++ b/dns/middleware.go
@@ -179,6 +179,10 @@ func newHandler(resolver *Resolver, mapper *ResolverEnhancer) handler {
 		middlewares = append(middlewares, withHosts(resolver.hosts))
 	}
 
+	if resolver.localHosts != nil {
+		middlewares = append(middlewares, withHosts(resolver.localHosts))
+	}
+
 	if mapper.mode == C.DNSFakeIP {
 		middlewares = append(middlewares, withFakeIP(mapper.fakePool))
 	}

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -33,6 +33,7 @@ type result struct {
 type Resolver struct {
 	ipv6                  bool
 	hosts                 *trie.DomainTrie
+	localHosts            *trie.DomainTrie
 	main                  []dnsClient
 	fallback              []dnsClient
 	fallbackDomainFilters []fallbackDomainFilter
@@ -322,6 +323,7 @@ type Config struct {
 	FallbackFilter FallbackFilter
 	Pool           *fakeip.Pool
 	Hosts          *trie.DomainTrie
+	LocalHosts     *trie.DomainTrie
 	Policy         map[string]NameServer
 }
 
@@ -332,10 +334,11 @@ func NewResolver(config Config) *Resolver {
 	}
 
 	r := &Resolver{
-		ipv6:     config.IPv6,
-		main:     transform(config.Main, defaultResolver),
-		lruCache: cache.NewLRUCache(cache.WithSize(4096), cache.WithStale(true)),
-		hosts:    config.Hosts,
+		ipv6:       config.IPv6,
+		main:       transform(config.Main, defaultResolver),
+		lruCache:   cache.NewLRUCache(cache.WithSize(4096), cache.WithStale(true)),
+		hosts:      config.Hosts,
+		localHosts: config.LocalHosts,
 	}
 
 	if len(config.Fallback) != 0 {

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -130,6 +130,10 @@ func updateDNS(c *config.DNS) {
 		Policy:  c.NameServerPolicy,
 	}
 
+	if c.LocalHosts {
+		cfg.LocalHosts = dns.LoadHosts()
+	}
+
 	r := dns.NewResolver(cfg)
 	m := dns.NewEnhancer(cfg)
 


### PR DESCRIPTION
### 效果

![image](https://user-images.githubusercontent.com/7552030/146925097-68e42e41-ac10-4f1a-adaf-6c439211f8ef.png)

### Purpose

在使用 clash 时仍能通过系统 hosts 便捷访问 debug 机，而不需要同时修改 clash 的配置文件和系统 hosts 文件

以及在移动平台与基于系统 hosts 的反广告方案兼容

### Limitation

 - 本地 Hosts 不影响 DoH 的解析，指定 DNS server 的 ip 应该在配置文件里，很合理
 - 没有实时重载 Hosts，或许可以挂个 fsnotify

---

此 PR 已在 macOS/Windows 平台测试

---

This PR may fix #1636 
