### PR TITLE
fix routing-mark option doesn't work on shadowsocks

### DIFF
--- a/adapter/outbound/http.go
+++ b/adapter/outbound/http.go
@@ -136,6 +136,7 @@ func NewHttp(option HttpOption) *Http {
 			addr:  net.JoinHostPort(option.Server, strconv.Itoa(option.Port)),
 			tp:    C.Http,
 			iface: option.Interface,
+			rmark: option.RoutingMark,
 		},
 		user:      option.UserName,
 		pass:      option.Password,

--- a/adapter/outbound/shadowsocks.go
+++ b/adapter/outbound/shadowsocks.go
@@ -160,6 +160,7 @@ func NewShadowSocks(option ShadowSocksOption) (*ShadowSocks, error) {
 			tp:    C.Shadowsocks,
 			udp:   option.UDP,
 			iface: option.Interface,
+			rmark: option.RoutingMark,
 		},
 		cipher: ciph,
 

--- a/adapter/outbound/shadowsocksr.go
+++ b/adapter/outbound/shadowsocksr.go
@@ -142,6 +142,7 @@ func NewShadowSocksR(option ShadowSocksROption) (*ShadowSocksR, error) {
 			tp:    C.ShadowsocksR,
 			udp:   option.UDP,
 			iface: option.Interface,
+			rmark: option.RoutingMark,
 		},
 		cipher:   coreCiph,
 		obfs:     obfs,

--- a/adapter/outbound/snell.go
+++ b/adapter/outbound/snell.go
@@ -116,6 +116,7 @@ func NewSnell(option SnellOption) (*Snell, error) {
 			addr:  addr,
 			tp:    C.Snell,
 			iface: option.Interface,
+			rmark: option.RoutingMark,
 		},
 		psk:        psk,
 		obfsOption: obfsOption,

--- a/adapter/outbound/socks5.go
+++ b/adapter/outbound/socks5.go
@@ -154,6 +154,7 @@ func NewSocks5(option Socks5Option) *Socks5 {
 			tp:    C.Socks5,
 			udp:   option.UDP,
 			iface: option.Interface,
+			rmark: option.RoutingMark,
 		},
 		user:           option.UserName,
 		pass:           option.Password,

--- a/adapter/outbound/trojan.go
+++ b/adapter/outbound/trojan.go
@@ -173,6 +173,7 @@ func NewTrojan(option TrojanOption) (*Trojan, error) {
 			tp:    C.Trojan,
 			udp:   option.UDP,
 			iface: option.Interface,
+			rmark: option.RoutingMark,
 		},
 		instance: trojan.New(tOption),
 		option:   &option,

--- a/adapter/outbound/vmess.go
+++ b/adapter/outbound/vmess.go
@@ -280,6 +280,7 @@ func NewVmess(option VmessOption) (*Vmess, error) {
 			tp:    C.Vmess,
 			udp:   option.UDP,
 			iface: option.Interface,
+			rmark: option.RoutingMark,
 		},
 		client: client,
 		option: &option,


### PR DESCRIPTION
Hi,
I found that the routing-mark option under shadowsocks doesn't make any effect. This pull request fixed it.