### PR TITLE
When processing data through `json.Unmarshal`, `port` thinks it is `float64`, which causes the parsing node to report an error

### DIFF
--- a/common/structure/structure.go
+++ b/common/structure/structure.go
@@ -91,6 +91,8 @@ func (d *Decoder) decodeInt(name string, data any, val reflect.Value) (err error
 	switch {
 	case kind == reflect.Int:
 		val.SetInt(dataVal.Int())
+	case kind == reflect.Float64:
+		val.SetInt(int64(dataVal.Float()))
 	case kind == reflect.String && d.option.WeaklyTypedInput:
 		var i int64
 		i, err = strconv.ParseInt(dataVal.String(), 0, val.Type().Bits())

--- a/common/structure/structure.go
+++ b/common/structure/structure.go
@@ -91,7 +91,7 @@ func (d *Decoder) decodeInt(name string, data any, val reflect.Value) (err error
 	switch {
 	case kind == reflect.Int:
 		val.SetInt(dataVal.Int())
-	case kind == reflect.Float64:
+	case kind == reflect.Float64 && d.option.WeaklyTypedInput:
 		val.SetInt(int64(dataVal.Float()))
 	case kind == reflect.String && d.option.WeaklyTypedInput:
 		var i int64


### PR DESCRIPTION
When processing data through `json.Unmarshal`, `port` thinks it is `float64`, which causes the parsing node to report an error