### PR TITLE
Feature: Add strategy: sticky-sessions for LoadBalance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=clash
 BINDIR=bin
-VERSION=$(shell git describe --tags || echo "unknown version")
+VERSION=$(shell git describe --tags || echo "unknownVersion")
 BUILDTIME=$(shell date -u)
 GOBUILD=CGO_ENABLED=0 go build -trimpath -ldflags '-X "github.com/Dreamacro/clash/constant.Version=$(VERSION)" \
 		-X "github.com/Dreamacro/clash/constant.BuildTime=$(BUILDTIME)" \

--- a/adapter/outboundgroup/loadbalance.go
+++ b/adapter/outboundgroup/loadbalance.go
@@ -142,6 +142,19 @@ func strategyStickySessions() strategyFn {
 		time time.Time
 	}
 	Sessions := make(map[string]map[string]Session)
+	go func() {
+		for true {
+			time.Sleep(time.Second * 60)
+			now := time.Now().Unix()
+			for _, subMap := range Sessions {
+				for dest, session := range subMap {
+					if now-session.time.Unix() > timeout {
+						delete(subMap, dest)
+					}
+				}
+			}
+		}
+	}()
 	return func(proxies []C.Proxy, metadata *C.Metadata) C.Proxy {
 		src := metadata.SrcIP.String()
 		dest := getKey(metadata)

--- a/adapter/outboundgroup/loadbalance.go
+++ b/adapter/outboundgroup/loadbalance.go
@@ -138,9 +138,8 @@ func strategyConsistentHashing() strategyFn {
 func strategyStickySessions() strategyFn {
 	timeout := int64(600)
 	type Session struct {
-		available bool
-		idx       int
-		time      time.Time
+		idx  int
+		time time.Time
 	}
 	Sessions := make(map[string]map[string]Session)
 	return func(proxies []C.Proxy, metadata *C.Metadata) C.Proxy {
@@ -151,11 +150,10 @@ func strategyStickySessions() strategyFn {
 		if Sessions[src] == nil {
 			Sessions[src] = make(map[string]Session)
 		}
-		session := Sessions[src][dest]
-		if !session.available || now.Unix()-session.time.Unix() > timeout {
+		session, ok := Sessions[src][dest]
+		if !ok || now.Unix()-session.time.Unix() > timeout {
 			session.idx = rand.Intn(length)
 		}
-		session.available = true
 		session.time = now
 
 		var i int

--- a/adapter/outboundgroup/loadbalance.go
+++ b/adapter/outboundgroup/loadbalance.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
+	"time"
 
 	"github.com/Dreamacro/clash/adapter/outbound"
 	"github.com/Dreamacro/clash/common/murmur3"
@@ -133,6 +135,49 @@ func strategyConsistentHashing() strategyFn {
 	}
 }
 
+func strategyStickySessions() strategyFn {
+	timeout := int64(600)
+	type Session struct {
+		available bool
+		idx       int
+		time      time.Time
+	}
+	Sessions := make(map[string]map[string]Session)
+	return func(proxies []C.Proxy, metadata *C.Metadata) C.Proxy {
+		src := metadata.SrcIP.String()
+		dest := getKey(metadata)
+		now := time.Now()
+		length := len(proxies)
+		if Sessions[src] == nil {
+			Sessions[src] = make(map[string]Session)
+		}
+		session := Sessions[src][dest]
+		if !session.available || now.Unix()-session.time.Unix() > timeout {
+			session.idx = rand.Intn(length)
+		}
+		session.available = true
+		session.time = now
+
+		var i int
+		var res C.Proxy
+		for i := 0; i < length; i++ {
+			idx := (session.idx + i) % length
+			proxy := proxies[idx]
+			if proxy.Alive() {
+				session.idx = idx
+				res = proxy
+				break
+			}
+		}
+		if i == length {
+			session.idx = 0
+			res = proxies[0]
+		}
+		Sessions[src][dest] = session
+		return res
+	}
+}
+
 // Unwrap implements C.ProxyAdapter
 func (lb *LoadBalance) Unwrap(metadata *C.Metadata) C.Proxy {
 	proxies := lb.proxies(true)
@@ -166,6 +211,8 @@ func NewLoadBalance(option *GroupCommonOption, providers []provider.ProxyProvide
 		strategyFn = strategyConsistentHashing()
 	case "round-robin":
 		strategyFn = strategyRoundRobin()
+	case "sticky-sessions":
+		strategyFn = strategyStickySessions()
 	default:
 		return nil, fmt.Errorf("%w: %s", errStrategy, strategy)
 	}


### PR DESCRIPTION
添加一个负载均衡策略
为相同的SrcIP和相同的eTLD在10分钟内选择相同的proxy。
相比于ConsistentHashing，StickySessions能在透明网关下带来更均衡的负载。