### PR TITLE
[F] Fixed the problem that the full path was incorrectly encoded due …

### DIFF
--- a/transport/vmess/websocket.go
+++ b/transport/vmess/websocket.go
@@ -260,14 +260,14 @@ func streamWebsocketConn(conn net.Conn, c *WebsocketConfig, earlyData *bytes.Buf
 	if err != nil {
 		return nil, fmt.Errorf("parse url %s error: %w", c.Path, err)
 	}
-	
+
 	uri := url.URL{
-		Scheme:    scheme,
-		Host:      net.JoinHostPort(c.Host, c.Port),
-		Path:      u.Path,
-		RawQuery:  u.RawQuery,
+		Scheme:   scheme,
+		Host:     net.JoinHostPort(c.Host, c.Port),
+		Path:     u.Path,
+		RawQuery: u.RawQuery,
 	}
-	
+
 	headers := http.Header{}
 	if c.Headers != nil {
 		for k := range c.Headers {

--- a/transport/vmess/websocket.go
+++ b/transport/vmess/websocket.go
@@ -258,7 +258,7 @@ func streamWebsocketConn(conn net.Conn, c *WebsocketConfig, earlyData *bytes.Buf
 
 	u, err := url.Parse(c.Path)
 	if err != nil {
-		return nil, fmt.Errorf("parse url[%s]: %s", c.Path, err)
+		return nil, fmt.Errorf("parse url %s error: %w", c.Path, err)
 	}
 	uri := url.URL{
 		Scheme:    scheme,
@@ -266,7 +266,6 @@ func streamWebsocketConn(conn net.Conn, c *WebsocketConfig, earlyData *bytes.Buf
 		Path:      u.Path,
 		RawQuery:  u.RawQuery,
 	}
-
 
 	headers := http.Header{}
 	if c.Headers != nil {

--- a/transport/vmess/websocket.go
+++ b/transport/vmess/websocket.go
@@ -266,7 +266,6 @@ func streamWebsocketConn(conn net.Conn, c *WebsocketConfig, earlyData *bytes.Buf
 		Path:      u.Path,
 		RawQuery:  u.RawQuery,
 	}
-
 	headers := http.Header{}
 	if c.Headers != nil {
 		for k := range c.Headers {

--- a/transport/vmess/websocket.go
+++ b/transport/vmess/websocket.go
@@ -260,12 +260,14 @@ func streamWebsocketConn(conn net.Conn, c *WebsocketConfig, earlyData *bytes.Buf
 	if err != nil {
 		return nil, fmt.Errorf("parse url %s error: %w", c.Path, err)
 	}
+	
 	uri := url.URL{
 		Scheme:    scheme,
 		Host:      net.JoinHostPort(c.Host, c.Port),
 		Path:      u.Path,
 		RawQuery:  u.RawQuery,
 	}
+	
 	headers := http.Header{}
 	if c.Headers != nil {
 		for k := range c.Headers {

--- a/transport/vmess/websocket.go
+++ b/transport/vmess/websocket.go
@@ -256,11 +256,17 @@ func streamWebsocketConn(conn net.Conn, c *WebsocketConfig, earlyData *bytes.Buf
 		dialer.TLSClientConfig = c.TLSConfig
 	}
 
-	uri := url.URL{
-		Scheme: scheme,
-		Host:   net.JoinHostPort(c.Host, c.Port),
-		Path:   c.Path,
+	u, err := url.Parse(c.Path)
+	if err != nil {
+		return nil, fmt.Errorf("parse url[%s]: %s", c.Path, err)
 	}
+	uri := url.URL{
+		Scheme:    scheme,
+		Host:      net.JoinHostPort(c.Host, c.Port),
+		Path:      u.Path,
+		RawQuery:  u.RawQuery,
+	}
+
 
 	headers := http.Header{}
 	if c.Headers != nil {


### PR DESCRIPTION
Fixed the problem that the full path was incorrectly encoded due to missing QueryParam

Clash LOG:time="2022-07-09T22:36:32+09:00" level=warning msg="[TCP] dial DEF (match Match/) to [domain]:443 error: dial [domain]:443 error: 404 Not Found"
Server LOG:[ip] - - [09/Jul/2022:22:34:59 -0400] "GET /[path]%3F[query] HTTP/1.1" 404 1457 "-" "Go-http-client/1.1"

As seen in the logs "?" was encoded as "%3F" by the URL, which resulted in a 404 error
