### PR TITLE
add HTTPS support for external controller

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,9 @@ type Controller struct {
 	ExternalController string `json:"-"`
 	ExternalUI         string `json:"-"`
 	Secret             string `json:"-"`
+	ExternalTLS        bool   `json:"-"`
+	TLSCertPath        string `json:"-"`
+	TLSKeyPath         string `json:"-"`
 }
 
 // DNS config
@@ -137,6 +140,9 @@ type RawConfig struct {
 	ExternalController string       `yaml:"external-controller"`
 	ExternalUI         string       `yaml:"external-ui"`
 	Secret             string       `yaml:"secret"`
+	ExternalTLS        bool         `yaml:"external-tls"`
+	TLSCertPath        string       `yaml:"tls-cert-file"`
+	TLSKeyPath         string       `yaml:"tls-key-file"`
 	Interface          string       `yaml:"interface-name"`
 	RoutingMark        int          `yaml:"routing-mark"`
 
@@ -252,6 +258,7 @@ func parseGeneral(cfg *RawConfig) (*General, error) {
 		}
 	}
 
+
 	return &General{
 		Inbound: Inbound{
 			Port:        cfg.Port,
@@ -266,6 +273,9 @@ func parseGeneral(cfg *RawConfig) (*General, error) {
 			ExternalController: cfg.ExternalController,
 			ExternalUI:         cfg.ExternalUI,
 			Secret:             cfg.Secret,
+			ExternalTLS:        cfg.ExternalTLS,
+			TLSCertPath:        cfg.TLSCertPath,
+			TLSKeyPath:         cfg.TLSKeyPath,
 		},
 		Mode:        cfg.Mode,
 		LogLevel:    cfg.LogLevel,

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -26,6 +26,24 @@ func WithSecret(secret string) Option {
 	}
 }
 
+func WithExternalTLS(externalTLS bool) Option {
+	return func(cfg *config.Config) {
+		cfg.General.ExternalTLS = externalTLS
+	}
+}
+
+func WithTLSCertPath(tLSCertPath string) Option {
+	return func(cfg *config.Config) {
+		cfg.General.TLSCertPath = tLSCertPath
+	}
+}
+
+func WithTLSKeyPath(tLSKeyPath string) Option {
+	return func(cfg *config.Config) {
+		cfg.General.TLSKeyPath = tLSKeyPath
+	}
+}
+
 // Parse call at the beginning of clash
 func Parse(options ...Option) error {
 	cfg, err := executor.Parse()
@@ -35,6 +53,10 @@ func Parse(options ...Option) error {
 
 	for _, option := range options {
 		option(cfg)
+	}
+
+	if (cfg.General.ExternalTLS) {
+		route.SetTLS(cfg.General.TLSCertPath,cfg.General.TLSKeyPath)
 	}
 
 	if cfg.General.ExternalUI != "" {

--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -24,6 +24,9 @@ var (
 	serverAddr   = ""
 
 	uiPath = ""
+	
+	certPath = ""
+	keyPath  = ""
 
 	upgrader = websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
@@ -35,6 +38,11 @@ var (
 type Traffic struct {
 	Up   int64 `json:"up"`
 	Down int64 `json:"down"`
+}
+
+func SetTLS(certpath string, keypath string) {
+	certPath = C.Path.Resolve(certpath)
+	keyPath = C.Path.Resolve(keypath)
 }
 
 func SetUIPath(path string) {
@@ -90,7 +98,14 @@ func Start(addr string, secret string) {
 	}
 	serverAddr = l.Addr().String()
 	log.Infoln("RESTful API listening at: %s", serverAddr)
-	if err = http.Serve(l, r); err != nil {
+
+	if len(certPath) > 0 && len(keyPath) > 0 {
+		err = http.ServeTLS(l, r, certPath, keyPath)
+	} else {
+		err = http.Serve(l, r)
+	}
+
+	if err != nil {
 		log.Errorln("External controller serve error: %s", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,9 @@ var (
 	externalUI         string
 	externalController string
 	secret             string
+	externalTLS        bool
+	tLSCertPath        string
+	tLSKeyPath         string
 )
 
 func init() {
@@ -35,6 +38,9 @@ func init() {
 	flag.StringVar(&externalUI, "ext-ui", "", "override external ui directory")
 	flag.StringVar(&externalController, "ext-ctl", "", "override external controller address")
 	flag.StringVar(&secret, "secret", "", "override secret for RESTful API")
+	flag.StringVar(&tLSCertPath, "tls-crt", "", "override HTTP server cert path")
+	flag.StringVar(&tLSKeyPath, "tls-key", "", "override HTTP server key path")	
+	flag.BoolVar(&externalTLS, "ext-tls", false, "override TLS parameters")
 	flag.BoolVar(&version, "v", false, "show current version of clash")
 	flag.BoolVar(&testConfig, "t", false, "test configuration and exit")
 	flag.Parse()
@@ -94,6 +100,15 @@ func main() {
 	}
 	if flagset["secret"] {
 		options = append(options, hub.WithSecret(secret))
+	}
+	if flagset["ext-tls"] {
+		options = append(options, hub.WithExternalTLS(externalTLS))
+	}
+	if flagset["tls-crt"] {
+		options = append(options, hub.WithTLSCertPath(tLSCertPath))
+	}
+	if flagset["tls-key"] {
+		options = append(options, hub.WithTLSKeyPath(tLSKeyPath))
 	}
 
 	if err := hub.Parse(options...); err != nil {


### PR DESCRIPTION
>The site http://yacd.haishan.me/ is served with HTTP not HTTPS is because many browsers block requests to HTTP resources from a HTTPS website. If you think it's not safe, you could just download the [zip of the gh-pages](https://github.com/haishanh/yacd/archive/gh-pages.zip), unzip and serve those static files with a web server(like Nginx).

In order to solve this, I make this commit to add HTTPS support for external controller. Config is as follows:
```yaml
external-controller: 127.0.0.1:9090
external-ui: yacd
secret: ""
external-tls: true
tls-cert-file: path_to_cert
tls-key-file: path_to_key
```