### PR TITLE
refactor: update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,24 @@
-FROM golang:alpine as builder
+FROM --platform=${BUILDPLATFORM} golang:alpine as builder
 
-RUN apk add --no-cache make git && \
+RUN apk add --no-cache make git ca-certificates tzdata && \
     wget -O /Country.mmdb https://github.com/Dreamacro/maxmind-geoip/releases/latest/download/Country.mmdb
 WORKDIR /clash-src
 COPY --from=tonistiigi/xx:golang / /
-COPY . /clash-src
-RUN go mod download && \
-    make docker && \
-    mv ./bin/clash-docker /clash
+ARG TARGETOS TARGETARCH
 
-FROM alpine:latest
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    CGO_ENABLED=0 go build -trimpath -ldflags '-X "github.com/Dreamacro/clash/constant.Version=$(VERSION)" \
+		-X "github.com/Dreamacro/clash/constant.BuildTime=$(BUILDTIME)" \
+		-w -s -buildid=' -o /clash
+
+FROM scratch
 LABEL org.opencontainers.image.source="https://github.com/Dreamacro/clash"
 
-RUN apk add --no-cache ca-certificates tzdata
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /Country.mmdb /root/.config/clash/
 COPY --from=builder /clash /
 ENTRYPOINT ["/clash"]

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,6 @@ WINDOWS_ARCH_LIST = \
 
 all: linux-amd64 darwin-amd64 windows-amd64 # Most used
 
-docker:
-	$(GOBUILD) -o $(BINDIR)/$(NAME)-$@
-
 darwin-amd64:
 	GOARCH=amd64 GOOS=darwin $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
 


### PR DESCRIPTION
* Instead of separating the Go module download, we could remove this and just use a cache mount for ```/go/pkg/mod```
* ```COPY``` will create an extra layer in the container image which slows things down and uses extra disk space. This can be avoided by using ```RUN --mount``` and bind mounting from the build context, from a stage, or an image.
* add a cross compiling targets to the Dockerfile: ```TARGETOS``` & ```TARGETARCH```
* add ```BUILDPLATFORM``` -> matches current machines CPU architecture (eg. linux/amd64)
* go build reduced by 1/3 and the image size has been reduced by 1/4 (22MB->16MB)

Useful links:
https://www.docker.com/blog/containerize-your-go-developer-environment-part-1/
https://www.reddit.com/r/golang/comments/q7zppz/docker_cache_for_dependencies/
https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/