### PR TITLE
Add back go1.18 support

### DIFF
--- a/component/process/process_linux.go
+++ b/component/process/process_linux.go
@@ -133,7 +133,7 @@ func resolveProcessNameByProcSearch(inode, uid uint32) (string, error) {
 	}
 
 	buffer := make([]byte, unix.PathMax)
-	socket := fmt.Appendf(nil, "socket:[%d]", inode)
+	socket := []byte(fmt.Sprintf("socket:[%d]", inode))
 
 	for _, f := range files {
 		if !f.IsDir() || !isPid(f.Name()) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dreamacro/clash
 
-go 1.19
+go 1.18
 
 require (
 	github.com/go-chi/chi/v5 v5.0.7


### PR DESCRIPTION
Some people still need this stable version that is still supported by Go.