### PR TITLE
增加Provider配置可以选的user-agent配置

### DIFF
--- a/adapter/provider/parser.go
+++ b/adapter/provider/parser.go
@@ -22,7 +22,7 @@ type healthCheckSchema struct {
 type proxyProviderSchema struct {
 	Type        string            `provider:"type"`
 	Path        string            `provider:"path"`
-	UserAgent   string            `provider:"user-agent"`
+	UserAgent   string            `provider:"user-agent,omitempty"`
 	URL         string            `provider:"url,omitempty"`
 	Interval    int               `provider:"interval,omitempty"`
 	Filter      string            `provider:"filter,omitempty"`

--- a/adapter/provider/parser.go
+++ b/adapter/provider/parser.go
@@ -22,6 +22,7 @@ type healthCheckSchema struct {
 type proxyProviderSchema struct {
 	Type        string            `provider:"type"`
 	Path        string            `provider:"path"`
+	UserAgent   string            `provider:"user-agent"`
 	URL         string            `provider:"url,omitempty"`
 	Interval    int               `provider:"interval,omitempty"`
 	Filter      string            `provider:"filter,omitempty"`
@@ -53,7 +54,7 @@ func ParseProxyProvider(name string, mapping map[string]any) (types.ProxyProvide
 	case "file":
 		vehicle = NewFileVehicle(path)
 	case "http":
-		vehicle = NewHTTPVehicle(schema.URL, path)
+		vehicle = NewHTTPVehicle(schema.URL, path, schema.UserAgent)
 	default:
 		return nil, fmt.Errorf("%w: %s", errVehicleType, schema.Type)
 	}

--- a/adapter/provider/vehicle.go
+++ b/adapter/provider/vehicle.go
@@ -34,8 +34,9 @@ func NewFileVehicle(path string) *FileVehicle {
 }
 
 type HTTPVehicle struct {
-	url  string
-	path string
+	url       string
+	path      string
+	userAgent string
 }
 
 func (h *HTTPVehicle) Type() types.VehicleType {
@@ -66,7 +67,9 @@ func (h *HTTPVehicle) Read() ([]byte, error) {
 	}
 
 	req = req.WithContext(ctx)
-
+	if h.userAgent != "" {
+		req.Header.Set("User-Agent", h.userAgent)
+	}
 	transport := &http.Transport{
 		// from http.DefaultTransport
 		MaxIdleConns:          100,
@@ -93,6 +96,6 @@ func (h *HTTPVehicle) Read() ([]byte, error) {
 	return buf, nil
 }
 
-func NewHTTPVehicle(url string, path string) *HTTPVehicle {
-	return &HTTPVehicle{url, path}
+func NewHTTPVehicle(url string, path string, userAgent string) *HTTPVehicle {
+	return &HTTPVehicle{url, path, userAgent}
 }


### PR DESCRIPTION
有的订阅连接根据user-agent判断下发的节点格式，手动指定user-agent可以具备更好的灵活性