### PR TITLE
fix: when get request url /logs, wsConn == nil return req

### DIFF
--- a/hub/route/server.go
+++ b/hub/route/server.go
@@ -206,6 +206,7 @@ func getLogs(w http.ResponseWriter, r *http.Request) {
 	if wsConn == nil {
 		w.Header().Set("Content-Type", "application/json")
 		render.Status(r, http.StatusOK)
+		return
 	}
 
 	ch := make(chan log.Event, 1024)


### PR DESCRIPTION
当发起 get 请求 /logs，在 wsConn == nil 的时候没有 return