### PR TITLE
Feature: cache available ip

### DIFF
--- a/component/dialer/dns_optimizer.go
+++ b/component/dialer/dns_optimizer.go
@@ -1,0 +1,30 @@
+package dialer
+
+import (
+	"github.com/Dreamacro/clash/common/cache"
+	"github.com/Dreamacro/clash/log"
+	"net"
+	"time"
+)
+
+const ttl = 600 * time.Second
+
+var lruCache = cache.New(cache.WithSize(4096), cache.WithStale(true))
+
+func getIP(host string) (net.IP, bool) {
+	ip, ok := lruCache.Get(host)
+	if !ok {
+		return nil, ok
+	}
+	return ip.(net.IP), ok
+}
+
+func setIP(host string, ip net.IP) {
+	log.Debugln("[DNS cache] set %s --> %s", host, ip)
+	lruCache.SetWithExpire(host, ip, time.Now().Add(ttl))
+}
+
+func deleteIP(host string) {
+	log.Debugln("[DNS cache] delete %s", host)
+	lruCache.Delete(host)
+}


### PR DESCRIPTION
In many cases our proxy server has many ips, especially when it's behind a cdn, but not all of them are able to connect, the connectivity of which even vary from region to region. Given that the choise of ip in a dns lookup is random, if the proxy server has four ips and two of them are blocked, then 50% of the requests may fail.

So this PR enables clash to "memorize" available ip. On each dial to proxy server it looks up dns from a cache, add the record to cache if the dial is successful and remove it on failure. 