### PR TITLE
Feature: add support for search domains

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ type DNS struct {
 	FakeIPRange       *fakeip.Pool
 	Hosts             *trie.DomainTrie
 	NameServerPolicy  map[string]dns.NameServer
+	SearchDomains     []string
 }
 
 // FallbackFilter config
@@ -117,6 +118,7 @@ type RawDNS struct {
 	FakeIPFilter      []string          `yaml:"fake-ip-filter"`
 	DefaultNameserver []string          `yaml:"default-nameserver"`
 	NameServerPolicy  map[string]string `yaml:"nameserver-policy"`
+	SearchDomains     []string          `yaml:"search-domains"`
 }
 
 type RawFallbackFilter struct {
@@ -700,6 +702,18 @@ func parseDNS(rawCfg *RawConfig, hosts *trie.DomainTrie) (*DNS, error) {
 
 	if cfg.UseHosts {
 		dnsCfg.Hosts = hosts
+	}
+
+	if len(cfg.SearchDomains) != 0 {
+		for _, domain := range cfg.SearchDomains {
+			if strings.HasPrefix(domain, ".") || strings.HasSuffix(domain, ".") {
+				return nil, errors.New("search domains should not start or end with '.'")
+			}
+			if strings.Contains(domain, ":") {
+				return nil, errors.New("search domains are for ipv4 only and should not contain ports")
+			}
+		}
+		dnsCfg.SearchDomains = cfg.SearchDomains
 	}
 
 	return dnsCfg, nil

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -298,7 +298,7 @@ func (r *Resolver) lookupIP(ctx context.Context, host string, dnsType uint16) ([
 		return nil, resolver.ErrIPNotFound
 	}
 
-	// query DNS servers in parallel for each search domain
+	// query provided search domains serially
 	for _, domain := range r.searchDomains {
 		q := &D.Msg{}
 		q.SetQuestion(D.Fqdn(fmt.Sprintf("%s.%s", host, domain)), dnsType)

--- a/hub/executor/executor.go
+++ b/hub/executor/executor.go
@@ -129,8 +129,9 @@ func updateDNS(c *config.DNS) {
 			IPCIDR:    c.FallbackFilter.IPCIDR,
 			Domain:    c.FallbackFilter.Domain,
 		},
-		Default: c.DefaultNameserver,
-		Policy:  c.NameServerPolicy,
+		Default:       c.DefaultNameserver,
+		Policy:        c.NameServerPolicy,
+		SearchDomains: c.SearchDomains,
 	}
 
 	r := dns.NewResolver(cfg)


### PR DESCRIPTION
Environments like `docker` and `kubernetes` often have default DNS resolvers that contain [search domains](https://en.wikipedia.org/wiki/Search_domain) that make service discovery easier. For example, within a single Kubernetes namespace, I can reach a Postgres pod at `http://postgres` without needing to specify the fully qualified name. For example:

```
$ cat /etc/resolv.conf
nameserver 172.10.0.10
search my-namespace.svc.cluster.local svc.cluster.local cluster.local us-west-2.compute.internal
options ndots:5
```

Unfortunately, there is no way to preserve this configuration when using `fake-ip` in `clash` today. If the `search` field is left in the `/etc/resolv.conf` and the `resolv.conf` is changed so that all DNS queries go to clash's resolver at `0.0.0.0:53`, **all** queries will have the search domain automatically appended, even if it is not needed. For example:

```
WARN[0001] [TCP] dial http (match Match/) 10.50.0.101:48866 --> postgres.my-namespace.svc.cluster.local.my-namespace.svc.cluster.local:5432 error: 503 Service Unavailable
```

This PR allows users to configure search domains they would like to add to queries if the first query does not succeed. This mimics the default linux behavior. Queries are done in parallel and thus the performance hit should be minimal. Finally, since search domains are only applied during the true DNS resolution flow, the fake-ip pool is not affected.