### PR TITLE
Fix: Adjust DNS TTL values based on minimum value

### DIFF
--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -143,7 +143,8 @@ func (r *Resolver) ExchangeContext(ctx context.Context, m *D.Msg) (msg *D.Msg, e
 			setMsgTTL(msg, uint32(1)) // Continue fetch
 			go r.exchangeWithoutCache(ctx, m)
 		} else {
-			setMsgTTL(msg, uint32(time.Until(expireTime).Seconds()))
+			// updating TTL by subtracting common delta time from each DNS record
+			updateMsgTTL(msg, uint32(time.Until(expireTime).Seconds()))
 		}
 		return
 	}

--- a/dns/util.go
+++ b/dns/util.go
@@ -29,7 +29,7 @@ func updateTTL(records []D.RR, ttl uint32) {
 	}
 	delta := minimalTTL(records) - ttl
 	for i := range records {
-		records[i].Header().Ttl -= delta
+		records[i].Header().Ttl = lo.Clamp(records[i].Header().Ttl-delta, 1, records[i].Header().Ttl)
 	}
 }
 

--- a/dns/util.go
+++ b/dns/util.go
@@ -57,6 +57,20 @@ func putMsgToCache(c *cache.LruCache, key string, q D.Question, msg *D.Msg) {
 }
 
 func setMsgTTL(msg *D.Msg, ttl uint32) {
+	for _, answer := range msg.Answer {
+		answer.Header().Ttl = ttl
+	}
+
+	for _, ns := range msg.Ns {
+		ns.Header().Ttl = ttl
+	}
+
+	for _, extra := range msg.Extra {
+		extra.Header().Ttl = ttl
+	}
+}
+
+func updateMsgTTL(msg *D.Msg, ttl uint32) {
 	updateTTL(msg.Answer, ttl)
 	updateTTL(msg.Ns, ttl)
 	updateTTL(msg.Extra, ttl)

--- a/dns/util.go
+++ b/dns/util.go
@@ -12,18 +12,15 @@ import (
 	"github.com/Dreamacro/clash/common/cache"
 	"github.com/Dreamacro/clash/common/picker"
 	"github.com/Dreamacro/clash/log"
+	"github.com/samber/lo"
 
 	D "github.com/miekg/dns"
 )
 
 func minimalTTL(records []D.RR) uint32 {
-	ttl := records[0].Header().Ttl
-	for i := range records {
-		if records[i].Header().Ttl < ttl {
-			ttl = records[i].Header().Ttl
-		}
-	}
-	return ttl
+	return lo.MinBy(records, func(r1 D.RR, r2 D.RR) bool {
+		return r1.Header().Ttl < r2.Header().Ttl
+	}).Header().Ttl
 }
 
 func updateTTL(records []D.RR, ttl uint32) {

--- a/dns/util.go
+++ b/dns/util.go
@@ -12,9 +12,9 @@ import (
 	"github.com/Dreamacro/clash/common/cache"
 	"github.com/Dreamacro/clash/common/picker"
 	"github.com/Dreamacro/clash/log"
-	"github.com/samber/lo"
 
 	D "github.com/miekg/dns"
+	"github.com/samber/lo"
 )
 
 func minimalTTL(records []D.RR) uint32 {


### PR DESCRIPTION
## Problem
The following code uses the TTL of the very first record, as the whole TTL of the response,
https://github.com/Dreamacro/clash/blob/df61a586c9df496c2ab71790534b0cab5d9e47ba/dns/util.go#L28-L33


and these codes further use the previous TTL as the TTL of each entry in answers.
https://github.com/Dreamacro/clash/blob/df61a586c9df496c2ab71790534b0cab5d9e47ba/dns/util.go#L42-L55

This will cause issue when the first answer in the DNS message is greater than the later record.

For example, in the first DNS query
```bash
╰─❯ dog epdg.epc.mnc260.mcc310.pub.3gppnetwork.org A @openwrt.lan
CNAME epdg.epc.mnc260.mcc310.pub.3gppnetwork.org.     5h49m11s   "epdg.epc.geo.mnc260.mcc310.pub.3gppnetwork.org."
    A epdg.epc.geo.mnc260.mcc310.pub.3gppnetwork.org.      17s   208.54.39.163
```

And the second cached query will cause the answer of A type to have a much greater TTL value, which should be expected to expire after 17 seconds after the first query.
```bash
╰─❯ dog epdg.epc.mnc260.mcc310.pub.3gppnetwork.org A @openwrt.lan
CNAME epdg.epc.mnc260.mcc310.pub.3gppnetwork.org.     5h49m07s   "epdg.epc.geo.mnc260.mcc310.pub.3gppnetwork.org."
    A epdg.epc.geo.mnc260.mcc310.pub.3gppnetwork.org. 5h49m07s   208.54.39.163
```

## Resolution
To resolve the issues, this commit adds modify `updateTTL` function that adjusts the TTL values of DNS records based on the minimum TTL value found in the records list instead of the first record. When updating the TTL it calculates the passed delta time and subtracts it to all cached TTL values.  This ensures consistency in the cache expiry time for all records to prevent caching issues.