### PR TITLE
Fix: PacketConn's internal remote address is overwritten

### DIFF
--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -39,7 +39,7 @@ func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, oAddr, 
 			return
 		}
 
-		fromUDPAddr := from.(*net.UDPAddr)
+		fromUDPAddr := *from.(*net.UDPAddr)
 		if fAddr.IsValid() {
 			fromAddr, _ := netip.AddrFromSlice(fromUDPAddr.IP)
 			fromAddr = fromAddr.Unmap()
@@ -48,7 +48,7 @@ func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, oAddr, 
 			}
 		}
 
-		_, err = packet.WriteBack(buf[:n], fromUDPAddr)
+		_, err = packet.WriteBack(buf[:n], &fromUDPAddr)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
When using vmess + fake-ip, after receiving the first UDP response, PacketConn's internal address will be rewritten to fake-ip, causing all subsequent sending operations to return "ErrUDPRemoteAddrMismatch".


```diff
diff --git a/tunnel/connection.go b/tunnel/connection.go
index 0614603..c220908 100644
--- a/tunnel/connection.go
+++ b/tunnel/connection.go
@@ -39,7 +39,7 @@ func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, oAddr,
                        return
                }

-               fromUDPAddr := from.(*net.UDPAddr)
+               fromUDPAddr := *from.(*net.UDPAddr)
                if fAddr.IsValid() {
                        fromAddr, _ := netip.AddrFromSlice(fromUDPAddr.IP)
                        fromAddr = fromAddr.Unmap()
@@ -48,7 +48,7 @@ func handleUDPToLocal(packet C.UDPPacket, pc net.PacketConn, key string, oAddr,
                        }
                }

-               _, err = packet.WriteBack(buf[:n], fromUDPAddr)
+               _, err = packet.WriteBack(buf[:n], &fromUDPAddr)
                if err != nil {
                        return
                }
```