### PR TITLE
Feature: proxy has different available states based on different URLs

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-const DefaultUrl = "_clash"
+const DefaultUrl = "_clash_"
 
 type Proxy struct {
 	C.ProxyAdapter

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -26,21 +26,17 @@ type Proxy struct {
 // Alive implements C.Proxy
 func (p *Proxy) Alive(url string) bool {
 	if url == "" {
-		alive := true
-		init := true
+		times := 0
 		p.alive.Range(func(key, value any) bool {
-			if init {
-				init = false
-				alive = false
-			}
+			times = times + 1
 			a := value.(*atomic.Bool)
 			if a.Load() {
-				alive = true
+				times = 0
 				return false
 			}
 			return true
 		})
-		return alive
+		return times == 0
 	} else {
 		if v, ok := p.alive.Load(url); ok {
 			return v.(*atomic.Bool).Load()

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -17,14 +17,10 @@ import (
 	"go.uber.org/atomic"
 )
 
-const DefaultUrl = "_clash_"
-
 type Proxy struct {
 	C.ProxyAdapter
 	history sync.Map
 	alive   sync.Map
-	//history map[string]*queue.Queue
-	//alive   map[string]*atomic.Bool
 }
 
 // Alive implements C.Proxy
@@ -152,7 +148,6 @@ func (p *Proxy) MarshalJSON() ([]byte, error) {
 	}
 	mapping := map[string]any{}
 	json.Unmarshal(inner, &mapping)
-	//mapping["history"] = p.DelayHistory(url)
 	mapping["history"] = p.FlatDelayHistories()
 	mapping["histories"] = p.DelayHistories()
 	mapping["name"] = p.Name()

--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -64,6 +64,7 @@ func (f *Fallback) MarshalJSON() ([]byte, error) {
 		"type": f.Type().String(),
 		"now":  f.Now(),
 		"all":  all,
+		"url":  f.url,
 	})
 }
 

--- a/adapter/outboundgroup/fallback.go
+++ b/adapter/outboundgroup/fallback.go
@@ -16,6 +16,7 @@ type Fallback struct {
 	disableUDP bool
 	single     *singledo.Single
 	providers  []provider.ProxyProvider
+	url        string
 }
 
 func (f *Fallback) Now() string {
@@ -83,7 +84,7 @@ func (f *Fallback) proxies(touch bool) []C.Proxy {
 func (f *Fallback) findAliveProxy(touch bool) C.Proxy {
 	proxies := f.proxies(touch)
 	for _, proxy := range proxies {
-		if proxy.Alive() {
+		if proxy.Alive(f.url) {
 			return proxy
 		}
 	}
@@ -102,5 +103,6 @@ func NewFallback(option *GroupCommonOption, providers []provider.ProxyProvider) 
 		single:     singledo.NewSingle(defaultGetProxiesDuration),
 		providers:  providers,
 		disableUDP: option.DisableUDP,
+		url:        option.URL,
 	}
 }

--- a/adapter/outboundgroup/loadbalance.go
+++ b/adapter/outboundgroup/loadbalance.go
@@ -161,7 +161,7 @@ func (lb *LoadBalance) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(map[string]any{
 		"type": lb.Type().String(),
-		"all":  all,
+		"all":  all, "url": lb.url,
 	})
 }
 

--- a/adapter/outboundgroup/urltest.go
+++ b/adapter/outboundgroup/urltest.go
@@ -122,6 +122,7 @@ func (u *URLTest) MarshalJSON() ([]byte, error) {
 		"type": u.Type().String(),
 		"now":  u.Now(),
 		"all":  all,
+		"url":  u.url,
 	})
 }
 

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -104,6 +104,7 @@ type DelayHistory struct {
 	Time      time.Time `json:"time"`
 	Delay     uint16    `json:"delay"`
 	MeanDelay uint16    `json:"meanDelay"`
+	URL       string    `json:"url"`
 }
 
 type Proxy interface {

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -108,9 +108,11 @@ type DelayHistory struct {
 
 type Proxy interface {
 	ProxyAdapter
-	Alive() bool
-	DelayHistory() []DelayHistory
-	LastDelay() uint16
+	Alive(url string) bool
+	StoreAlive(url string, alive bool)
+	DelayHistory(url string) []DelayHistory
+	DelayHistories() map[string][]DelayHistory
+	LastDelay(url string) uint16
 	URLTest(ctx context.Context, url string) (uint16, uint16, error)
 
 	// Deprecated: use DialContext instead.

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -69,6 +69,7 @@ type Metadata struct {
 	SrcPort      string  `json:"sourcePort"`
 	DstPort      string  `json:"destinationPort"`
 	Host         string  `json:"host"`
+	Url          string  `json:"url"`
 	DNSMode      DNSMode `json:"dnsMode"`
 	ProcessPath  string  `json:"processPath"`
 	SpecialProxy string  `json:"specialProxy"`


### PR DESCRIPTION
The available status of the proxy is based on the url-test.url, and each url-test.url has its own status, so that different url can be written in different groups.
This can solve many problems in the issues and compatible with existing UI Dashboard.
By the way, if the UI Dashboard (yacd?) needs to display the URL-based delay of the group , it needs to judge the URL in the history.