### PR TITLE
add PassThrough AdapterType

### DIFF
--- a/adapter/outbound/pass_through.go
+++ b/adapter/outbound/pass_through.go
@@ -1,0 +1,33 @@
+package outbound
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Dreamacro/clash/component/dialer"
+	C "github.com/Dreamacro/clash/constant"
+)
+
+type PassThrough struct {
+	*Base
+}
+
+// DialContext implements C.ProxyAdapter
+func (p *PassThrough) DialContext(ctx context.Context, metadata *C.Metadata, opts ...dialer.Option) (C.Conn, error) {
+	return nil, errors.New("no support")
+}
+
+// ListenPacketContext implements C.ProxyAdapter
+func (p *PassThrough) ListenPacketContext(ctx context.Context, metadata *C.Metadata, opts ...dialer.Option) (C.PacketConn, error) {
+	return nil, errors.New("no support")
+}
+
+func NewPassThrough() *PassThrough {
+	return &PassThrough{
+		Base: &Base{
+			name: "PASS_THROUGH",
+			tp:   C.PassThrough,
+			udp:  true,
+		},
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -358,7 +358,8 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 
 	proxies["DIRECT"] = adapter.NewProxy(outbound.NewDirect())
 	proxies["REJECT"] = adapter.NewProxy(outbound.NewReject())
-	proxyList = append(proxyList, "DIRECT", "REJECT")
+	proxies["PASS_THROUGH"] = adapter.NewProxy(outbound.NewPassThrough())
+	proxyList = append(proxyList, "DIRECT", "REJECT", "PASS_THROUGH")
 
 	// parse proxy
 	for idx, mapping := range proxiesConfig {

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -13,6 +13,7 @@ import (
 const (
 	Direct AdapterType = iota
 	Reject
+	PassThrough
 
 	Shadowsocks
 	ShadowsocksR
@@ -129,6 +130,8 @@ func (at AdapterType) String() string {
 		return "Direct"
 	case Reject:
 		return "Reject"
+	case PassThrough:
+		return "PassThrough"
 
 	case Shadowsocks:
 		return "Shadowsocks"

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -420,6 +420,14 @@ func match(metadata *C.Metadata) (C.Proxy, C.Rule, error) {
 				continue
 			}
 
+			if adapter.Type() == C.PassThrough {
+				continue
+			}
+			p := adapter.Unwrap(metadata)
+			if p != nil && p.Type() == C.PassThrough {
+				continue
+			}
+
 			if metadata.NetWork == C.UDP && !adapter.SupportUDP() && UDPFallbackMatch.Load() {
 				log.Debugln("[Matcher] %s UDP is not supported, skip match", adapter.Name())
 				continue


### PR DESCRIPTION
Implemented a new ProxyAdapter named PassThrough. When this ProxyAdapter is matched, no action is performed and the processing proceeds to the next rule. This AdapterType can be used in the following context: Using the SRC-IP-CIDR rule to match a local network host, then matching a select-type ProxyGroup specific to this host. The ProxyGroup includes "REJECT", "DIRECT", "xxxProxy", and "PASS_THROUGH" as options. By choosing the PASS_THROUGH option, the system enables further rule-based routing process.