### PR TITLE
Docs: fix typo in script.md

### DIFF
--- a/docs/premium/script.md
+++ b/docs/premium/script.md
@@ -7,7 +7,7 @@ sidebarOrder: 5
 
 Clash Premium implements the Scripting feature powered by Python3, enableing users to programmatically select policies for the packets with dynamic flexibility.
 
-You can either controll the entire rule-matching engine with a single Python script, or define a number of shortcuts and use them in companion with the regular rules. This page refers to the first feature, for the latter, see [Script Shortcuts](./script-shortcuts.md).
+You can either control the entire rule-matching engine with a single Python script, or define a number of shortcuts and use them in companion with the regular rules. This page refers to the first feature, for the latter, see [Script Shortcuts](./script-shortcuts.md).
 
 ## Scripting the entire rule-matching engine
 


### PR DESCRIPTION
controll -> control