### PR TITLE
Refactor(constant): added rule string enums in configs as RuleConfig for better outside integrations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,3 +22,5 @@ linters-settings:
       - default
   staticcheck:
     go: '1.21'
+  exhaustive:
+    default-signifies-exhaustive: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,7 @@ linters:
     - unconvert
     - unused
     - usestdlibvars
+    - exhaustive
 
 linters-settings:
   gci:

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -52,6 +52,8 @@ func (t Type) String() string {
 		return "Redir"
 	case TPROXY:
 		return "TProxy"
+	case TUNNEL:
+		return "Tunnel"
 	default:
 		return "Unknown"
 	}

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -1,5 +1,48 @@
 package constant
 
+// Rule Type String
+const (
+	DomainString        RuleTypeString = "Domain"
+	DomainSuffixString  RuleTypeString = "DomainSuffix"
+	DomainKeywordString RuleTypeString = "DomainKeyword"
+	GEOIPString         RuleTypeString = "GeoIP"
+	IPCIDRString        RuleTypeString = "IPCIDR"
+	SrcIPCIDRString     RuleTypeString = "SrcIPCIDR"
+	SrcPortString       RuleTypeString = "SrcPort"
+	DstPortString       RuleTypeString = "DstPort"
+	InboundPortString   RuleTypeString = "InboundPort"
+	ProcessString       RuleTypeString = "Process"
+	ProcessPathString   RuleTypeString = "ProcessPath"
+	IPSetString         RuleTypeString = "IPSet"
+	MatchString         RuleTypeString = "Match"
+	UnknownString       RuleTypeString = "Unknown"
+)
+
+// Rule Type String represents a rule type, if integrating with configuration files, please use RuleConfigTypeString instead.
+type RuleTypeString string
+
+const (
+	DomainConfigTypeString        RuleConfigTypeString = "DOMAIN"
+	DomainSuffixConfigTypeString  RuleConfigTypeString = "DOMAIN-SUFFIX"
+	DomainKeywordConfigTypeString RuleConfigTypeString = "DOMAIN-KEYWORD"
+	GeoIPConfigTypeString         RuleConfigTypeString = "GEOIP"
+	IPCIDRConfigTypeString        RuleConfigTypeString = "IP-CIDR"
+	IPCIDR6ConfigTypeString       RuleConfigTypeString = "IP-CIDR6"
+	SrcIPCIDRConfigTypeString     RuleConfigTypeString = "SRC-IP-CIDR"
+	SrcPortConfigTypeString       RuleConfigTypeString = "SRC-PORT"
+	DstPortConfigTypeString       RuleConfigTypeString = "DST-PORT"
+	InboundPortConfigTypeString   RuleConfigTypeString = "INBOUND-PORT"
+	ProcessNameConfigTypeString   RuleConfigTypeString = "PROCESS-NAME"
+	ProcessPathConfigTypeString   RuleConfigTypeString = "PROCESS-PATH"
+	IPSetConfigTypeString         RuleConfigTypeString = "IPSET"
+	RuleSetConfigTypeString       RuleConfigTypeString = "RULE-SET"
+	ScriptConfigTypeString        RuleConfigTypeString = "SCRIPT"
+	MatchConfigTypeString         RuleConfigTypeString = "MATCH"
+)
+
+// Rule Config Type String represents a rule type in configuration files. Only reference this type instead of RuleTypeString when making integrate and processing with configuration files.
+type RuleConfigTypeString string
+
 // Rule Type
 const (
 	Domain RuleType = iota
@@ -20,40 +63,45 @@ const (
 type RuleType int
 
 func (rt RuleType) String() string {
-	switch rt {
+	return string(rt.RuleTypeString())
+}
+
+func (rts RuleType) RuleTypeString() RuleTypeString {
+	switch rts {
 	case Domain:
-		return "Domain"
+		return DomainString
 	case DomainSuffix:
-		return "DomainSuffix"
+		return DomainSuffixString
 	case DomainKeyword:
-		return "DomainKeyword"
+		return DomainKeywordString
 	case GEOIP:
-		return "GeoIP"
+		return GEOIPString
 	case IPCIDR:
-		return "IPCIDR"
+		return IPCIDRString
 	case SrcIPCIDR:
-		return "SrcIPCIDR"
+		return SrcIPCIDRString
 	case SrcPort:
-		return "SrcPort"
+		return SrcPortString
 	case DstPort:
-		return "DstPort"
+		return DstPortString
 	case InboundPort:
-		return "InboundPort"
+		return InboundPortString
 	case Process:
-		return "Process"
+		return ProcessString
 	case ProcessPath:
-		return "ProcessPath"
+		return ProcessPathString
 	case IPSet:
-		return "IPSet"
+		return IPSetString
 	case MATCH:
-		return "Match"
+		return MatchString
 	default:
-		return "Unknown"
+		return UnknownString
 	}
 }
 
 type Rule interface {
 	RuleType() RuleType
+	RuleTypeString() RuleTypeString
 	Match(metadata *Metadata) bool
 	Adapter() string
 	Payload() string

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -5,7 +5,7 @@ const (
 	DomainString        RuleTypeString = "Domain"
 	DomainSuffixString  RuleTypeString = "DomainSuffix"
 	DomainKeywordString RuleTypeString = "DomainKeyword"
-	GEOIPString         RuleTypeString = "GeoIP"
+	GeoIPString         RuleTypeString = "GeoIP"
 	IPCIDRString        RuleTypeString = "IPCIDR"
 	SrcIPCIDRString     RuleTypeString = "SrcIPCIDR"
 	SrcPortString       RuleTypeString = "SrcPort"
@@ -75,7 +75,7 @@ func (rts RuleType) RuleTypeString() RuleTypeString {
 	case DomainKeyword:
 		return DomainKeywordString
 	case GEOIP:
-		return GEOIPString
+		return GeoIPString
 	case IPCIDR:
 		return IPCIDRString
 	case SrcIPCIDR:

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -1,47 +1,26 @@
 package constant
 
-// Rule Type String
 const (
-	DomainString        RuleTypeString = "Domain"
-	DomainSuffixString  RuleTypeString = "DomainSuffix"
-	DomainKeywordString RuleTypeString = "DomainKeyword"
-	GeoIPString         RuleTypeString = "GeoIP"
-	IPCIDRString        RuleTypeString = "IPCIDR"
-	SrcIPCIDRString     RuleTypeString = "SrcIPCIDR"
-	SrcPortString       RuleTypeString = "SrcPort"
-	DstPortString       RuleTypeString = "DstPort"
-	InboundPortString   RuleTypeString = "InboundPort"
-	ProcessString       RuleTypeString = "Process"
-	ProcessPathString   RuleTypeString = "ProcessPath"
-	IPSetString         RuleTypeString = "IPSet"
-	MatchString         RuleTypeString = "Match"
-	UnknownString       RuleTypeString = "Unknown"
+	DomainTypeString        RuleTypeString = "DOMAIN"
+	DomainSuffixTypeString  RuleTypeString = "DOMAIN-SUFFIX"
+	DomainKeywordTypeString RuleTypeString = "DOMAIN-KEYWORD"
+	GeoIPTypeString         RuleTypeString = "GEOIP"
+	IPCIDRTypeString        RuleTypeString = "IP-CIDR"
+	IPCIDR6TypeString       RuleTypeString = "IP-CIDR6"
+	SrcIPCIDRTypeString     RuleTypeString = "SRC-IP-CIDR"
+	SrcPortTypeString       RuleTypeString = "SRC-PORT"
+	DstPortTypeString       RuleTypeString = "DST-PORT"
+	InboundPortTypeString   RuleTypeString = "INBOUND-PORT"
+	ProcessNameTypeString   RuleTypeString = "PROCESS-NAME"
+	ProcessPathTypeString   RuleTypeString = "PROCESS-PATH"
+	IPSetTypeString         RuleTypeString = "IPSET"
+	RuleSetTypeString       RuleTypeString = "RULE-SET"
+	ScriptTypeString        RuleTypeString = "SCRIPT"
+	MatchTypeString         RuleTypeString = "MATCH"
 )
 
-// Rule Type String represents a rule type, if integrating with configuration files, please use RuleConfigTypeString instead.
+// Rule Config Type String represents a rule type in configuration files.
 type RuleTypeString string
-
-const (
-	DomainConfigTypeString        RuleConfigTypeString = "DOMAIN"
-	DomainSuffixConfigTypeString  RuleConfigTypeString = "DOMAIN-SUFFIX"
-	DomainKeywordConfigTypeString RuleConfigTypeString = "DOMAIN-KEYWORD"
-	GeoIPConfigTypeString         RuleConfigTypeString = "GEOIP"
-	IPCIDRConfigTypeString        RuleConfigTypeString = "IP-CIDR"
-	IPCIDR6ConfigTypeString       RuleConfigTypeString = "IP-CIDR6"
-	SrcIPCIDRConfigTypeString     RuleConfigTypeString = "SRC-IP-CIDR"
-	SrcPortConfigTypeString       RuleConfigTypeString = "SRC-PORT"
-	DstPortConfigTypeString       RuleConfigTypeString = "DST-PORT"
-	InboundPortConfigTypeString   RuleConfigTypeString = "INBOUND-PORT"
-	ProcessNameConfigTypeString   RuleConfigTypeString = "PROCESS-NAME"
-	ProcessPathConfigTypeString   RuleConfigTypeString = "PROCESS-PATH"
-	IPSetConfigTypeString         RuleConfigTypeString = "IPSET"
-	RuleSetConfigTypeString       RuleConfigTypeString = "RULE-SET"
-	ScriptConfigTypeString        RuleConfigTypeString = "SCRIPT"
-	MatchConfigTypeString         RuleConfigTypeString = "MATCH"
-)
-
-// Rule Config Type String represents a rule type in configuration files. Only reference this type instead of RuleTypeString when making integrate and processing with configuration files.
-type RuleConfigTypeString string
 
 // Rule Type
 const (
@@ -63,45 +42,40 @@ const (
 type RuleType int
 
 func (rt RuleType) String() string {
-	return string(rt.RuleTypeString())
-}
-
-func (rts RuleType) RuleTypeString() RuleTypeString {
-	switch rts {
+	switch rt {
 	case Domain:
-		return DomainString
+		return "Domain"
 	case DomainSuffix:
-		return DomainSuffixString
+		return "DomainSuffix"
 	case DomainKeyword:
-		return DomainKeywordString
+		return "DomainKeyword"
 	case GEOIP:
-		return GeoIPString
+		return "GeoIP"
 	case IPCIDR:
-		return IPCIDRString
+		return "IPCIDR"
 	case SrcIPCIDR:
-		return SrcIPCIDRString
+		return "SrcIPCIDR"
 	case SrcPort:
-		return SrcPortString
+		return "SrcPort"
 	case DstPort:
-		return DstPortString
+		return "DstPort"
 	case InboundPort:
-		return InboundPortString
+		return "InboundPort"
 	case Process:
-		return ProcessString
+		return "Process"
 	case ProcessPath:
-		return ProcessPathString
+		return "ProcessPath"
 	case IPSet:
-		return IPSetString
+		return "IPSet"
 	case MATCH:
-		return MatchString
+		return "Match"
 	default:
-		return UnknownString
+		return "Unknown"
 	}
 }
 
 type Rule interface {
 	RuleType() RuleType
-	RuleTypeString() RuleTypeString
 	Match(metadata *Metadata) bool
 	Adapter() string
 	Payload() string

--- a/constant/rule.go
+++ b/constant/rule.go
@@ -1,26 +1,26 @@
 package constant
 
 const (
-	DomainTypeString        RuleTypeString = "DOMAIN"
-	DomainSuffixTypeString  RuleTypeString = "DOMAIN-SUFFIX"
-	DomainKeywordTypeString RuleTypeString = "DOMAIN-KEYWORD"
-	GeoIPTypeString         RuleTypeString = "GEOIP"
-	IPCIDRTypeString        RuleTypeString = "IP-CIDR"
-	IPCIDR6TypeString       RuleTypeString = "IP-CIDR6"
-	SrcIPCIDRTypeString     RuleTypeString = "SRC-IP-CIDR"
-	SrcPortTypeString       RuleTypeString = "SRC-PORT"
-	DstPortTypeString       RuleTypeString = "DST-PORT"
-	InboundPortTypeString   RuleTypeString = "INBOUND-PORT"
-	ProcessNameTypeString   RuleTypeString = "PROCESS-NAME"
-	ProcessPathTypeString   RuleTypeString = "PROCESS-PATH"
-	IPSetTypeString         RuleTypeString = "IPSET"
-	RuleSetTypeString       RuleTypeString = "RULE-SET"
-	ScriptTypeString        RuleTypeString = "SCRIPT"
-	MatchTypeString         RuleTypeString = "MATCH"
+	RuleConfigDomain        RuleConfig = "DOMAIN"
+	RuleConfigDomainSuffix  RuleConfig = "DOMAIN-SUFFIX"
+	RuleConfigDomainKeyword RuleConfig = "DOMAIN-KEYWORD"
+	RuleConfigGeoIP         RuleConfig = "GEOIP"
+	RuleConfigIPCIDR        RuleConfig = "IP-CIDR"
+	RuleConfigIPCIDR6       RuleConfig = "IP-CIDR6"
+	RuleConfigSrcIPCIDR     RuleConfig = "SRC-IP-CIDR"
+	RuleConfigSrcPort       RuleConfig = "SRC-PORT"
+	RuleConfigDstPort       RuleConfig = "DST-PORT"
+	RuleConfigInboundPort   RuleConfig = "INBOUND-PORT"
+	RuleConfigProcessName   RuleConfig = "PROCESS-NAME"
+	RuleConfigProcessPath   RuleConfig = "PROCESS-PATH"
+	RuleConfigIPSet         RuleConfig = "IPSET"
+	RuleConfigRuleSet       RuleConfig = "RULE-SET"
+	RuleConfigScript        RuleConfig = "SCRIPT"
+	RuleConfigMatch         RuleConfig = "MATCH"
 )
 
 // Rule Config Type String represents a rule type in configuration files.
-type RuleTypeString string
+type RuleConfig string
 
 // Rule Type
 const (

--- a/log/log.go
+++ b/log/log.go
@@ -79,7 +79,7 @@ func print(data Event) {
 		return
 	}
 
-	switch data.LogLevel {
+	switch data.LogLevel { // nolint:exhaustive
 	case INFO:
 		log.Infoln(data.Payload)
 	case WARNING:

--- a/log/log.go
+++ b/log/log.go
@@ -79,7 +79,7 @@ func print(data Event) {
 		return
 	}
 
-	switch data.LogLevel { // nolint:exhaustive
+	switch data.LogLevel {
 	case INFO:
 		log.Infoln(data.Payload)
 	case WARNING:
@@ -88,6 +88,8 @@ func print(data Event) {
 		log.Errorln(data.Payload)
 	case DEBUG:
 		log.Debugln(data.Payload)
+	case SILENT:
+		return
 	}
 }
 

--- a/rule/domain.go
+++ b/rule/domain.go
@@ -18,10 +18,6 @@ func (d *Domain) RuleType() C.RuleType {
 	return C.Domain
 }
 
-func (d *Domain) RuleTypeString() C.RuleTypeString {
-	return C.DomainString
-}
-
 func (d *Domain) Match(metadata *C.Metadata) bool {
 	return metadata.Host == d.domain
 }

--- a/rule/domain.go
+++ b/rule/domain.go
@@ -6,6 +6,9 @@ import (
 	C "github.com/Dreamacro/clash/constant"
 )
 
+// Implements C.Rule
+var _ C.Rule = (*Domain)(nil)
+
 type Domain struct {
 	domain  string
 	adapter string
@@ -13,6 +16,10 @@ type Domain struct {
 
 func (d *Domain) RuleType() C.RuleType {
 	return C.Domain
+}
+
+func (d *Domain) RuleTypeString() C.RuleTypeString {
+	return C.DomainString
 }
 
 func (d *Domain) Match(metadata *C.Metadata) bool {

--- a/rule/domain_keyword.go
+++ b/rule/domain_keyword.go
@@ -18,10 +18,6 @@ func (dk *DomainKeyword) RuleType() C.RuleType {
 	return C.DomainKeyword
 }
 
-func (dk *DomainKeyword) RuleTypeString() C.RuleTypeString {
-	return C.DomainKeywordString
-}
-
 func (dk *DomainKeyword) Match(metadata *C.Metadata) bool {
 	return strings.Contains(metadata.Host, dk.keyword)
 }

--- a/rule/domain_keyword.go
+++ b/rule/domain_keyword.go
@@ -6,6 +6,9 @@ import (
 	C "github.com/Dreamacro/clash/constant"
 )
 
+// Implements C.Rule
+var _ C.Rule = (*DomainKeyword)(nil)
+
 type DomainKeyword struct {
 	keyword string
 	adapter string
@@ -13,6 +16,10 @@ type DomainKeyword struct {
 
 func (dk *DomainKeyword) RuleType() C.RuleType {
 	return C.DomainKeyword
+}
+
+func (dk *DomainKeyword) RuleTypeString() C.RuleTypeString {
+	return C.DomainKeywordString
 }
 
 func (dk *DomainKeyword) Match(metadata *C.Metadata) bool {

--- a/rule/domain_suffix.go
+++ b/rule/domain_suffix.go
@@ -18,10 +18,6 @@ func (ds *DomainSuffix) RuleType() C.RuleType {
 	return C.DomainSuffix
 }
 
-func (ds *DomainSuffix) RuleTypeString() C.RuleTypeString {
-	return C.DomainSuffixString
-}
-
 func (ds *DomainSuffix) Match(metadata *C.Metadata) bool {
 	domain := metadata.Host
 	return strings.HasSuffix(domain, "."+ds.suffix) || domain == ds.suffix

--- a/rule/domain_suffix.go
+++ b/rule/domain_suffix.go
@@ -6,6 +6,9 @@ import (
 	C "github.com/Dreamacro/clash/constant"
 )
 
+// Implements C.Rule
+var _ C.Rule = (*DomainSuffix)(nil)
+
 type DomainSuffix struct {
 	suffix  string
 	adapter string
@@ -13,6 +16,10 @@ type DomainSuffix struct {
 
 func (ds *DomainSuffix) RuleType() C.RuleType {
 	return C.DomainSuffix
+}
+
+func (ds *DomainSuffix) RuleTypeString() C.RuleTypeString {
+	return C.DomainSuffixString
 }
 
 func (ds *DomainSuffix) Match(metadata *C.Metadata) bool {

--- a/rule/final.go
+++ b/rule/final.go
@@ -4,12 +4,19 @@ import (
 	C "github.com/Dreamacro/clash/constant"
 )
 
+// Implements C.Rule
+var _ C.Rule = (*Match)(nil)
+
 type Match struct {
 	adapter string
 }
 
 func (f *Match) RuleType() C.RuleType {
 	return C.MATCH
+}
+
+func (f *Match) RuleTypeString() C.RuleTypeString {
+	return C.MatchString
 }
 
 func (f *Match) Match(metadata *C.Metadata) bool {

--- a/rule/final.go
+++ b/rule/final.go
@@ -15,10 +15,6 @@ func (f *Match) RuleType() C.RuleType {
 	return C.MATCH
 }
 
-func (f *Match) RuleTypeString() C.RuleTypeString {
-	return C.MatchString
-}
-
 func (f *Match) Match(metadata *C.Metadata) bool {
 	return true
 }

--- a/rule/geoip.go
+++ b/rule/geoip.go
@@ -7,6 +7,9 @@ import (
 	C "github.com/Dreamacro/clash/constant"
 )
 
+// Implements C.Rule
+var _ C.Rule = (*GEOIP)(nil)
+
 type GEOIP struct {
 	country     string
 	adapter     string
@@ -15,6 +18,10 @@ type GEOIP struct {
 
 func (g *GEOIP) RuleType() C.RuleType {
 	return C.GEOIP
+}
+
+func (g *GEOIP) RuleTypeString() C.RuleTypeString {
+	return C.GEOIPString
 }
 
 func (g *GEOIP) Match(metadata *C.Metadata) bool {

--- a/rule/geoip.go
+++ b/rule/geoip.go
@@ -21,7 +21,7 @@ func (g *GEOIP) RuleType() C.RuleType {
 }
 
 func (g *GEOIP) RuleTypeString() C.RuleTypeString {
-	return C.GEOIPString
+	return C.GeoIPString
 }
 
 func (g *GEOIP) Match(metadata *C.Metadata) bool {

--- a/rule/geoip.go
+++ b/rule/geoip.go
@@ -20,10 +20,6 @@ func (g *GEOIP) RuleType() C.RuleType {
 	return C.GEOIP
 }
 
-func (g *GEOIP) RuleTypeString() C.RuleTypeString {
-	return C.GeoIPString
-}
-
 func (g *GEOIP) Match(metadata *C.Metadata) bool {
 	ip := metadata.DstIP
 	if ip == nil {

--- a/rule/ipcidr.go
+++ b/rule/ipcidr.go
@@ -20,6 +20,9 @@ func WithIPCIDRNoResolve(noResolve bool) IPCIDROption {
 	}
 }
 
+// Implements C.Rule
+var _ C.Rule = (*IPCIDR)(nil)
+
 type IPCIDR struct {
 	ipnet       *net.IPNet
 	adapter     string
@@ -32,6 +35,13 @@ func (i *IPCIDR) RuleType() C.RuleType {
 		return C.SrcIPCIDR
 	}
 	return C.IPCIDR
+}
+
+func (i *IPCIDR) RuleTypeString() C.RuleTypeString {
+	if i.isSourceIP {
+		return C.SrcIPCIDRString
+	}
+	return C.IPCIDRString
 }
 
 func (i *IPCIDR) Match(metadata *C.Metadata) bool {

--- a/rule/ipcidr.go
+++ b/rule/ipcidr.go
@@ -37,13 +37,6 @@ func (i *IPCIDR) RuleType() C.RuleType {
 	return C.IPCIDR
 }
 
-func (i *IPCIDR) RuleTypeString() C.RuleTypeString {
-	if i.isSourceIP {
-		return C.SrcIPCIDRString
-	}
-	return C.IPCIDRString
-}
-
 func (i *IPCIDR) Match(metadata *C.Metadata) bool {
 	ip := metadata.DstIP
 	if i.isSourceIP {

--- a/rule/ipset.go
+++ b/rule/ipset.go
@@ -6,6 +6,9 @@ import (
 	"github.com/Dreamacro/clash/log"
 )
 
+// Implements C.Rule
+var _ C.Rule = (*IPSet)(nil)
+
 type IPSet struct {
 	name        string
 	adapter     string
@@ -14,6 +17,10 @@ type IPSet struct {
 
 func (f *IPSet) RuleType() C.RuleType {
 	return C.IPSet
+}
+
+func (f *IPSet) RuleTypeString() C.RuleTypeString {
+	return C.IPSetString
 }
 
 func (f *IPSet) Match(metadata *C.Metadata) bool {

--- a/rule/ipset.go
+++ b/rule/ipset.go
@@ -19,10 +19,6 @@ func (f *IPSet) RuleType() C.RuleType {
 	return C.IPSet
 }
 
-func (f *IPSet) RuleTypeString() C.RuleTypeString {
-	return C.IPSetString
-}
-
 func (f *IPSet) Match(metadata *C.Metadata) bool {
 	exist, err := ipset.Test(f.name, metadata.DstIP)
 	if err != nil {

--- a/rule/parser.go
+++ b/rule/parser.go
@@ -12,36 +12,40 @@ func ParseRule(tp, payload, target string, params []string) (C.Rule, error) {
 		parsed   C.Rule
 	)
 
-	switch tp {
-	case "DOMAIN":
+	ruleConfigType := C.RuleConfigTypeString(tp)
+
+	switch ruleConfigType {
+	case C.DomainConfigTypeString:
 		parsed = NewDomain(payload, target)
-	case "DOMAIN-SUFFIX":
+	case C.DomainSuffixConfigTypeString:
 		parsed = NewDomainSuffix(payload, target)
-	case "DOMAIN-KEYWORD":
+	case C.DomainKeywordConfigTypeString:
 		parsed = NewDomainKeyword(payload, target)
-	case "GEOIP":
+	case C.GeoIPConfigTypeString:
 		noResolve := HasNoResolve(params)
 		parsed = NewGEOIP(payload, target, noResolve)
-	case "IP-CIDR", "IP-CIDR6":
+	case C.IPCIDRConfigTypeString, C.IPCIDR6ConfigTypeString:
 		noResolve := HasNoResolve(params)
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRNoResolve(noResolve))
-	case "SRC-IP-CIDR":
+	case C.SrcIPCIDRConfigTypeString:
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRSourceIP(true), WithIPCIDRNoResolve(true))
-	case "SRC-PORT":
+	case C.SrcPortConfigTypeString:
 		parsed, parseErr = NewPort(payload, target, PortTypeSrc)
-	case "DST-PORT":
+	case C.DstPortConfigTypeString:
 		parsed, parseErr = NewPort(payload, target, PortTypeDest)
-	case "INBOUND-PORT":
+	case C.InboundPortConfigTypeString:
 		parsed, parseErr = NewPort(payload, target, PortTypeInbound)
-	case "PROCESS-NAME":
+	case C.ProcessNameConfigTypeString:
 		parsed, parseErr = NewProcess(payload, target, true)
-	case "PROCESS-PATH":
+	case C.ProcessPathConfigTypeString:
 		parsed, parseErr = NewProcess(payload, target, false)
-	case "IPSET":
+	case C.IPSetConfigTypeString:
 		noResolve := HasNoResolve(params)
 		parsed, parseErr = NewIPSet(payload, target, noResolve)
-	case "MATCH":
+	case C.MatchConfigTypeString:
 		parsed = NewMatch(target)
+	case C.RuleSetConfigTypeString, C.ScriptConfigTypeString:
+		parseErr = fmt.Errorf("unsupported rule type %s", tp)
 	default:
 		parseErr = fmt.Errorf("unsupported rule type %s", tp)
 	}

--- a/rule/parser.go
+++ b/rule/parser.go
@@ -12,39 +12,39 @@ func ParseRule(tp, payload, target string, params []string) (C.Rule, error) {
 		parsed   C.Rule
 	)
 
-	ruleConfigType := C.RuleTypeString(tp)
+	ruleConfigType := C.RuleConfig(tp)
 
 	switch ruleConfigType {
-	case C.DomainTypeString:
+	case C.RuleConfigDomain:
 		parsed = NewDomain(payload, target)
-	case C.DomainSuffixTypeString:
+	case C.RuleConfigDomainSuffix:
 		parsed = NewDomainSuffix(payload, target)
-	case C.DomainKeywordTypeString:
+	case C.RuleConfigDomainKeyword:
 		parsed = NewDomainKeyword(payload, target)
-	case C.GeoIPTypeString:
+	case C.RuleConfigGeoIP:
 		noResolve := HasNoResolve(params)
 		parsed = NewGEOIP(payload, target, noResolve)
-	case C.IPCIDRTypeString, C.IPCIDR6TypeString:
+	case C.RuleConfigIPCIDR, C.RuleConfigIPCIDR6:
 		noResolve := HasNoResolve(params)
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRNoResolve(noResolve))
-	case C.SrcIPCIDRTypeString:
+	case C.RuleConfigSrcIPCIDR:
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRSourceIP(true), WithIPCIDRNoResolve(true))
-	case C.SrcPortTypeString:
+	case C.RuleConfigSrcPort:
 		parsed, parseErr = NewPort(payload, target, PortTypeSrc)
-	case C.DstPortTypeString:
+	case C.RuleConfigDstPort:
 		parsed, parseErr = NewPort(payload, target, PortTypeDest)
-	case C.InboundPortTypeString:
+	case C.RuleConfigInboundPort:
 		parsed, parseErr = NewPort(payload, target, PortTypeInbound)
-	case C.ProcessNameTypeString:
+	case C.RuleConfigProcessName:
 		parsed, parseErr = NewProcess(payload, target, true)
-	case C.ProcessPathTypeString:
+	case C.RuleConfigProcessPath:
 		parsed, parseErr = NewProcess(payload, target, false)
-	case C.IPSetTypeString:
+	case C.RuleConfigIPSet:
 		noResolve := HasNoResolve(params)
 		parsed, parseErr = NewIPSet(payload, target, noResolve)
-	case C.MatchTypeString:
+	case C.RuleConfigMatch:
 		parsed = NewMatch(target)
-	case C.RuleSetTypeString, C.ScriptTypeString:
+	case C.RuleConfigRuleSet, C.RuleConfigScript:
 		parseErr = fmt.Errorf("unsupported rule type %s", tp)
 	default:
 		parseErr = fmt.Errorf("unsupported rule type %s", tp)

--- a/rule/parser.go
+++ b/rule/parser.go
@@ -12,39 +12,39 @@ func ParseRule(tp, payload, target string, params []string) (C.Rule, error) {
 		parsed   C.Rule
 	)
 
-	ruleConfigType := C.RuleConfigTypeString(tp)
+	ruleConfigType := C.RuleTypeString(tp)
 
 	switch ruleConfigType {
-	case C.DomainConfigTypeString:
+	case C.DomainTypeString:
 		parsed = NewDomain(payload, target)
-	case C.DomainSuffixConfigTypeString:
+	case C.DomainSuffixTypeString:
 		parsed = NewDomainSuffix(payload, target)
-	case C.DomainKeywordConfigTypeString:
+	case C.DomainKeywordTypeString:
 		parsed = NewDomainKeyword(payload, target)
-	case C.GeoIPConfigTypeString:
+	case C.GeoIPTypeString:
 		noResolve := HasNoResolve(params)
 		parsed = NewGEOIP(payload, target, noResolve)
-	case C.IPCIDRConfigTypeString, C.IPCIDR6ConfigTypeString:
+	case C.IPCIDRTypeString, C.IPCIDR6TypeString:
 		noResolve := HasNoResolve(params)
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRNoResolve(noResolve))
-	case C.SrcIPCIDRConfigTypeString:
+	case C.SrcIPCIDRTypeString:
 		parsed, parseErr = NewIPCIDR(payload, target, WithIPCIDRSourceIP(true), WithIPCIDRNoResolve(true))
-	case C.SrcPortConfigTypeString:
+	case C.SrcPortTypeString:
 		parsed, parseErr = NewPort(payload, target, PortTypeSrc)
-	case C.DstPortConfigTypeString:
+	case C.DstPortTypeString:
 		parsed, parseErr = NewPort(payload, target, PortTypeDest)
-	case C.InboundPortConfigTypeString:
+	case C.InboundPortTypeString:
 		parsed, parseErr = NewPort(payload, target, PortTypeInbound)
-	case C.ProcessNameConfigTypeString:
+	case C.ProcessNameTypeString:
 		parsed, parseErr = NewProcess(payload, target, true)
-	case C.ProcessPathConfigTypeString:
+	case C.ProcessPathTypeString:
 		parsed, parseErr = NewProcess(payload, target, false)
-	case C.IPSetConfigTypeString:
+	case C.IPSetTypeString:
 		noResolve := HasNoResolve(params)
 		parsed, parseErr = NewIPSet(payload, target, noResolve)
-	case C.MatchConfigTypeString:
+	case C.MatchTypeString:
 		parsed = NewMatch(target)
-	case C.RuleSetConfigTypeString, C.ScriptConfigTypeString:
+	case C.RuleSetTypeString, C.ScriptTypeString:
 		parseErr = fmt.Errorf("unsupported rule type %s", tp)
 	default:
 		parseErr = fmt.Errorf("unsupported rule type %s", tp)

--- a/rule/parser_test.go
+++ b/rule/parser_test.go
@@ -1,0 +1,171 @@
+package rules
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	C "github.com/Dreamacro/clash/constant"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRule(t *testing.T) {
+	type testCase struct {
+		tp            C.RuleConfigTypeString
+		payload       string
+		target        string
+		params        []string
+		expectedRule  C.Rule
+		expectedError error
+	}
+
+	policy := "DIRECT"
+
+	testCases := []testCase{
+		{
+			tp:           C.DomainConfigTypeString,
+			payload:      "example.com",
+			target:       policy,
+			expectedRule: NewDomain("example.com", policy),
+		},
+		{
+			tp:           C.DomainSuffixConfigTypeString,
+			payload:      "example.com",
+			target:       policy,
+			expectedRule: NewDomainSuffix("example.com", policy),
+		},
+		{
+			tp:           C.DomainKeywordConfigTypeString,
+			payload:      "example.com",
+			target:       policy,
+			expectedRule: NewDomainKeyword("example.com", policy),
+		},
+		{
+			tp:      C.GeoIPConfigTypeString,
+			payload: "CN",
+			target:  policy, params: []string{noResolve},
+			expectedRule: NewGEOIP("CN", policy, true),
+		},
+		{
+			tp:           C.IPCIDRConfigTypeString,
+			payload:      "127.0.0.0/8",
+			target:       policy,
+			expectedRule: lo.Must(NewIPCIDR("127.0.0.0/8", policy, WithIPCIDRNoResolve(false))),
+		},
+		{
+			tp:      C.IPCIDRConfigTypeString,
+			payload: "127.0.0.0/8",
+			target:  policy, params: []string{noResolve},
+			expectedRule: lo.Must(NewIPCIDR("127.0.0.0/8", policy, WithIPCIDRNoResolve(true))),
+		},
+		{
+			tp:           C.IPCIDR6ConfigTypeString,
+			payload:      "2001:db8::/32",
+			target:       policy,
+			expectedRule: lo.Must(NewIPCIDR("2001:db8::/32", policy, WithIPCIDRNoResolve(false))),
+		},
+		{
+			tp:      C.IPCIDR6ConfigTypeString,
+			payload: "2001:db8::/32",
+			target:  policy, params: []string{noResolve},
+			expectedRule: lo.Must(NewIPCIDR("2001:db8::/32", policy, WithIPCIDRNoResolve(true))),
+		},
+		{
+			tp:           C.SrcIPCIDRConfigTypeString,
+			payload:      "192.168.1.201/32",
+			target:       policy,
+			expectedRule: lo.Must(NewIPCIDR("192.168.1.201/32", policy, WithIPCIDRSourceIP(true), WithIPCIDRNoResolve(true))),
+		},
+		{
+			tp:           C.SrcPortConfigTypeString,
+			payload:      "80",
+			target:       policy,
+			expectedRule: lo.Must(NewPort("80", policy, PortTypeSrc)),
+		},
+		{
+			tp:           C.DstPortConfigTypeString,
+			payload:      "80",
+			target:       policy,
+			expectedRule: lo.Must(NewPort("80", policy, PortTypeDest)),
+		},
+		{
+			tp:           C.InboundPortConfigTypeString,
+			payload:      "80",
+			target:       policy,
+			expectedRule: lo.Must(NewPort("80", policy, PortTypeInbound)),
+		},
+		{
+			tp:           C.ProcessNameConfigTypeString,
+			payload:      "example.exe",
+			target:       policy,
+			expectedRule: lo.Must(NewProcess("example.exe", policy, true)),
+		},
+		{
+			tp:           C.ProcessPathConfigTypeString,
+			payload:      "C:\\Program Files\\example.exe",
+			target:       policy,
+			expectedRule: lo.Must(NewProcess("C:\\Program Files\\example.exe", policy, false)),
+		},
+		{
+			tp:           C.ProcessPathConfigTypeString,
+			payload:      "/opt/example/example",
+			target:       policy,
+			expectedRule: lo.Must(NewProcess("/opt/example/example", policy, false)),
+		},
+		{
+			tp:           C.IPSetConfigTypeString,
+			payload:      "example",
+			target:       policy,
+			expectedRule: lo.Must(NewIPSet("example", policy, true)),
+		},
+		{
+			tp:      C.IPSetConfigTypeString,
+			payload: "example",
+			target:  policy, params: []string{noResolve},
+			expectedRule: lo.Must(NewIPSet("example", policy, false)),
+		},
+		{
+			tp:           C.MatchConfigTypeString,
+			payload:      "example",
+			target:       policy,
+			expectedRule: NewMatch(policy),
+		},
+		{
+			tp:            C.RuleSetConfigTypeString,
+			payload:       "example",
+			target:        policy,
+			expectedError: fmt.Errorf("unsupported rule type %s", C.RuleSetConfigTypeString),
+		},
+		{
+			tp:            C.ScriptConfigTypeString,
+			payload:       "example",
+			target:        policy,
+			expectedError: fmt.Errorf("unsupported rule type %s", C.ScriptConfigTypeString),
+		},
+		{
+			tp:            "UNKNOWN",
+			payload:       "example",
+			target:        policy,
+			expectedError: errors.New("unsupported rule type UNKNOWN"),
+		},
+		{
+			tp:            "ABCD",
+			payload:       "example",
+			target:        policy,
+			expectedError: errors.New("unsupported rule type ABCD"),
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := ParseRule(string(tc.tp), tc.payload, tc.target, tc.params)
+		if tc.expectedError != nil {
+			require.Error(t, err)
+			assert.EqualError(t, err, tc.expectedError.Error())
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}

--- a/rule/parser_test.go
+++ b/rule/parser_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestParseRule(t *testing.T) {
 	type testCase struct {
-		tp            C.RuleConfigTypeString
+		tp            C.RuleTypeString
 		payload       string
 		target        string
 		params        []string
@@ -26,124 +26,124 @@ func TestParseRule(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			tp:           C.DomainConfigTypeString,
+			tp:           C.DomainTypeString,
 			payload:      "example.com",
 			target:       policy,
 			expectedRule: NewDomain("example.com", policy),
 		},
 		{
-			tp:           C.DomainSuffixConfigTypeString,
+			tp:           C.DomainSuffixTypeString,
 			payload:      "example.com",
 			target:       policy,
 			expectedRule: NewDomainSuffix("example.com", policy),
 		},
 		{
-			tp:           C.DomainKeywordConfigTypeString,
+			tp:           C.DomainKeywordTypeString,
 			payload:      "example.com",
 			target:       policy,
 			expectedRule: NewDomainKeyword("example.com", policy),
 		},
 		{
-			tp:      C.GeoIPConfigTypeString,
+			tp:      C.GeoIPTypeString,
 			payload: "CN",
 			target:  policy, params: []string{noResolve},
 			expectedRule: NewGEOIP("CN", policy, true),
 		},
 		{
-			tp:           C.IPCIDRConfigTypeString,
+			tp:           C.IPCIDRTypeString,
 			payload:      "127.0.0.0/8",
 			target:       policy,
 			expectedRule: lo.Must(NewIPCIDR("127.0.0.0/8", policy, WithIPCIDRNoResolve(false))),
 		},
 		{
-			tp:      C.IPCIDRConfigTypeString,
+			tp:      C.IPCIDRTypeString,
 			payload: "127.0.0.0/8",
 			target:  policy, params: []string{noResolve},
 			expectedRule: lo.Must(NewIPCIDR("127.0.0.0/8", policy, WithIPCIDRNoResolve(true))),
 		},
 		{
-			tp:           C.IPCIDR6ConfigTypeString,
+			tp:           C.IPCIDR6TypeString,
 			payload:      "2001:db8::/32",
 			target:       policy,
 			expectedRule: lo.Must(NewIPCIDR("2001:db8::/32", policy, WithIPCIDRNoResolve(false))),
 		},
 		{
-			tp:      C.IPCIDR6ConfigTypeString,
+			tp:      C.IPCIDR6TypeString,
 			payload: "2001:db8::/32",
 			target:  policy, params: []string{noResolve},
 			expectedRule: lo.Must(NewIPCIDR("2001:db8::/32", policy, WithIPCIDRNoResolve(true))),
 		},
 		{
-			tp:           C.SrcIPCIDRConfigTypeString,
+			tp:           C.SrcIPCIDRTypeString,
 			payload:      "192.168.1.201/32",
 			target:       policy,
 			expectedRule: lo.Must(NewIPCIDR("192.168.1.201/32", policy, WithIPCIDRSourceIP(true), WithIPCIDRNoResolve(true))),
 		},
 		{
-			tp:           C.SrcPortConfigTypeString,
+			tp:           C.SrcPortTypeString,
 			payload:      "80",
 			target:       policy,
 			expectedRule: lo.Must(NewPort("80", policy, PortTypeSrc)),
 		},
 		{
-			tp:           C.DstPortConfigTypeString,
+			tp:           C.DstPortTypeString,
 			payload:      "80",
 			target:       policy,
 			expectedRule: lo.Must(NewPort("80", policy, PortTypeDest)),
 		},
 		{
-			tp:           C.InboundPortConfigTypeString,
+			tp:           C.InboundPortTypeString,
 			payload:      "80",
 			target:       policy,
 			expectedRule: lo.Must(NewPort("80", policy, PortTypeInbound)),
 		},
 		{
-			tp:           C.ProcessNameConfigTypeString,
+			tp:           C.ProcessNameTypeString,
 			payload:      "example.exe",
 			target:       policy,
 			expectedRule: lo.Must(NewProcess("example.exe", policy, true)),
 		},
 		{
-			tp:           C.ProcessPathConfigTypeString,
+			tp:           C.ProcessPathTypeString,
 			payload:      "C:\\Program Files\\example.exe",
 			target:       policy,
 			expectedRule: lo.Must(NewProcess("C:\\Program Files\\example.exe", policy, false)),
 		},
 		{
-			tp:           C.ProcessPathConfigTypeString,
+			tp:           C.ProcessPathTypeString,
 			payload:      "/opt/example/example",
 			target:       policy,
 			expectedRule: lo.Must(NewProcess("/opt/example/example", policy, false)),
 		},
 		{
-			tp:           C.IPSetConfigTypeString,
+			tp:           C.IPSetTypeString,
 			payload:      "example",
 			target:       policy,
 			expectedRule: lo.Must(NewIPSet("example", policy, true)),
 		},
 		{
-			tp:      C.IPSetConfigTypeString,
+			tp:      C.IPSetTypeString,
 			payload: "example",
 			target:  policy, params: []string{noResolve},
 			expectedRule: lo.Must(NewIPSet("example", policy, false)),
 		},
 		{
-			tp:           C.MatchConfigTypeString,
+			tp:           C.MatchTypeString,
 			payload:      "example",
 			target:       policy,
 			expectedRule: NewMatch(policy),
 		},
 		{
-			tp:            C.RuleSetConfigTypeString,
+			tp:            C.RuleSetTypeString,
 			payload:       "example",
 			target:        policy,
-			expectedError: fmt.Errorf("unsupported rule type %s", C.RuleSetConfigTypeString),
+			expectedError: fmt.Errorf("unsupported rule type %s", C.RuleSetTypeString),
 		},
 		{
-			tp:            C.ScriptConfigTypeString,
+			tp:            C.ScriptTypeString,
 			payload:       "example",
 			target:        policy,
-			expectedError: fmt.Errorf("unsupported rule type %s", C.ScriptConfigTypeString),
+			expectedError: fmt.Errorf("unsupported rule type %s", C.ScriptTypeString),
 		},
 		{
 			tp:            "UNKNOWN",

--- a/rule/parser_test.go
+++ b/rule/parser_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestParseRule(t *testing.T) {
 	type testCase struct {
-		tp            C.RuleTypeString
+		tp            C.RuleConfig
 		payload       string
 		target        string
 		params        []string
@@ -26,124 +26,124 @@ func TestParseRule(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			tp:           C.DomainTypeString,
+			tp:           C.RuleConfigDomain,
 			payload:      "example.com",
 			target:       policy,
 			expectedRule: NewDomain("example.com", policy),
 		},
 		{
-			tp:           C.DomainSuffixTypeString,
+			tp:           C.RuleConfigDomainSuffix,
 			payload:      "example.com",
 			target:       policy,
 			expectedRule: NewDomainSuffix("example.com", policy),
 		},
 		{
-			tp:           C.DomainKeywordTypeString,
+			tp:           C.RuleConfigDomainKeyword,
 			payload:      "example.com",
 			target:       policy,
 			expectedRule: NewDomainKeyword("example.com", policy),
 		},
 		{
-			tp:      C.GeoIPTypeString,
+			tp:      C.RuleConfigGeoIP,
 			payload: "CN",
 			target:  policy, params: []string{noResolve},
 			expectedRule: NewGEOIP("CN", policy, true),
 		},
 		{
-			tp:           C.IPCIDRTypeString,
+			tp:           C.RuleConfigIPCIDR,
 			payload:      "127.0.0.0/8",
 			target:       policy,
 			expectedRule: lo.Must(NewIPCIDR("127.0.0.0/8", policy, WithIPCIDRNoResolve(false))),
 		},
 		{
-			tp:      C.IPCIDRTypeString,
+			tp:      C.RuleConfigIPCIDR,
 			payload: "127.0.0.0/8",
 			target:  policy, params: []string{noResolve},
 			expectedRule: lo.Must(NewIPCIDR("127.0.0.0/8", policy, WithIPCIDRNoResolve(true))),
 		},
 		{
-			tp:           C.IPCIDR6TypeString,
+			tp:           C.RuleConfigIPCIDR6,
 			payload:      "2001:db8::/32",
 			target:       policy,
 			expectedRule: lo.Must(NewIPCIDR("2001:db8::/32", policy, WithIPCIDRNoResolve(false))),
 		},
 		{
-			tp:      C.IPCIDR6TypeString,
+			tp:      C.RuleConfigIPCIDR6,
 			payload: "2001:db8::/32",
 			target:  policy, params: []string{noResolve},
 			expectedRule: lo.Must(NewIPCIDR("2001:db8::/32", policy, WithIPCIDRNoResolve(true))),
 		},
 		{
-			tp:           C.SrcIPCIDRTypeString,
+			tp:           C.RuleConfigSrcIPCIDR,
 			payload:      "192.168.1.201/32",
 			target:       policy,
 			expectedRule: lo.Must(NewIPCIDR("192.168.1.201/32", policy, WithIPCIDRSourceIP(true), WithIPCIDRNoResolve(true))),
 		},
 		{
-			tp:           C.SrcPortTypeString,
+			tp:           C.RuleConfigSrcPort,
 			payload:      "80",
 			target:       policy,
 			expectedRule: lo.Must(NewPort("80", policy, PortTypeSrc)),
 		},
 		{
-			tp:           C.DstPortTypeString,
+			tp:           C.RuleConfigDstPort,
 			payload:      "80",
 			target:       policy,
 			expectedRule: lo.Must(NewPort("80", policy, PortTypeDest)),
 		},
 		{
-			tp:           C.InboundPortTypeString,
+			tp:           C.RuleConfigInboundPort,
 			payload:      "80",
 			target:       policy,
 			expectedRule: lo.Must(NewPort("80", policy, PortTypeInbound)),
 		},
 		{
-			tp:           C.ProcessNameTypeString,
+			tp:           C.RuleConfigProcessName,
 			payload:      "example.exe",
 			target:       policy,
 			expectedRule: lo.Must(NewProcess("example.exe", policy, true)),
 		},
 		{
-			tp:           C.ProcessPathTypeString,
+			tp:           C.RuleConfigProcessPath,
 			payload:      "C:\\Program Files\\example.exe",
 			target:       policy,
 			expectedRule: lo.Must(NewProcess("C:\\Program Files\\example.exe", policy, false)),
 		},
 		{
-			tp:           C.ProcessPathTypeString,
+			tp:           C.RuleConfigProcessPath,
 			payload:      "/opt/example/example",
 			target:       policy,
 			expectedRule: lo.Must(NewProcess("/opt/example/example", policy, false)),
 		},
 		{
-			tp:           C.IPSetTypeString,
+			tp:           C.RuleConfigIPSet,
 			payload:      "example",
 			target:       policy,
 			expectedRule: lo.Must(NewIPSet("example", policy, true)),
 		},
 		{
-			tp:      C.IPSetTypeString,
+			tp:      C.RuleConfigIPSet,
 			payload: "example",
 			target:  policy, params: []string{noResolve},
 			expectedRule: lo.Must(NewIPSet("example", policy, false)),
 		},
 		{
-			tp:           C.MatchTypeString,
+			tp:           C.RuleConfigMatch,
 			payload:      "example",
 			target:       policy,
 			expectedRule: NewMatch(policy),
 		},
 		{
-			tp:            C.RuleSetTypeString,
+			tp:            C.RuleConfigRuleSet,
 			payload:       "example",
 			target:        policy,
-			expectedError: fmt.Errorf("unsupported rule type %s", C.RuleSetTypeString),
+			expectedError: fmt.Errorf("unsupported rule type %s", C.RuleConfigRuleSet),
 		},
 		{
-			tp:            C.ScriptTypeString,
+			tp:            C.RuleConfigScript,
 			payload:       "example",
 			target:        policy,
-			expectedError: fmt.Errorf("unsupported rule type %s", C.ScriptTypeString),
+			expectedError: fmt.Errorf("unsupported rule type %s", C.RuleConfigScript),
 		},
 		{
 			tp:            "UNKNOWN",

--- a/rule/port.go
+++ b/rule/port.go
@@ -37,19 +37,6 @@ func (p *Port) RuleType() C.RuleType {
 	}
 }
 
-func (p *Port) RuleTypeString() C.RuleTypeString {
-	switch p.portType {
-	case PortTypeSrc:
-		return C.SrcPortString
-	case PortTypeDest:
-		return C.DstPortString
-	case PortTypeInbound:
-		return C.InboundPortString
-	default:
-		panic(fmt.Errorf("unknown port type: %v", p.portType))
-	}
-}
-
 func (p *Port) Match(metadata *C.Metadata) bool {
 	switch p.portType {
 	case PortTypeSrc:

--- a/rule/port.go
+++ b/rule/port.go
@@ -15,6 +15,9 @@ const (
 	PortTypeInbound
 )
 
+// Implements C.Rule
+var _ C.Rule = (*Port)(nil)
+
 type Port struct {
 	adapter  string
 	port     C.Port
@@ -29,6 +32,19 @@ func (p *Port) RuleType() C.RuleType {
 		return C.DstPort
 	case PortTypeInbound:
 		return C.InboundPort
+	default:
+		panic(fmt.Errorf("unknown port type: %v", p.portType))
+	}
+}
+
+func (p *Port) RuleTypeString() C.RuleTypeString {
+	switch p.portType {
+	case PortTypeSrc:
+		return C.SrcPortString
+	case PortTypeDest:
+		return C.DstPortString
+	case PortTypeInbound:
+		return C.InboundPortString
 	default:
 		panic(fmt.Errorf("unknown port type: %v", p.portType))
 	}

--- a/rule/process.go
+++ b/rule/process.go
@@ -7,6 +7,9 @@ import (
 	C "github.com/Dreamacro/clash/constant"
 )
 
+// Implements C.Rule
+var _ C.Rule = (*Process)(nil)
+
 type Process struct {
 	adapter  string
 	process  string
@@ -19,6 +22,14 @@ func (ps *Process) RuleType() C.RuleType {
 	}
 
 	return C.ProcessPath
+}
+
+func (ps *Process) RuleTypeString() C.RuleTypeString {
+	if ps.nameOnly {
+		return C.ProcessString
+	}
+
+	return C.ProcessPathString
 }
 
 func (ps *Process) Match(metadata *C.Metadata) bool {

--- a/rule/process.go
+++ b/rule/process.go
@@ -24,14 +24,6 @@ func (ps *Process) RuleType() C.RuleType {
 	return C.ProcessPath
 }
 
-func (ps *Process) RuleTypeString() C.RuleTypeString {
-	if ps.nameOnly {
-		return C.ProcessString
-	}
-
-	return C.ProcessPathString
-}
-
 func (ps *Process) Match(metadata *C.Metadata) bool {
 	if ps.nameOnly {
 		return strings.EqualFold(filepath.Base(metadata.ProcessPath), ps.process)

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -160,7 +160,7 @@ func resolveMetadata(ctx C.PlainContext, metadata *C.Metadata) (proxy C.Proxy, r
 		return
 	}
 
-	switch mode {
+	switch mode { //nolint:exhaustive
 	case Direct:
 		proxy = proxies["DIRECT"]
 	case Global:

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -160,15 +160,17 @@ func resolveMetadata(ctx C.PlainContext, metadata *C.Metadata) (proxy C.Proxy, r
 		return
 	}
 
-	switch mode { //nolint:exhaustive
+	switch mode {
 	case Direct:
 		proxy = proxies["DIRECT"]
 	case Global:
 		proxy = proxies["GLOBAL"]
-	// Rule
-	default:
+	case Rule:
 		proxy, rule, err = match(metadata)
+	default:
+		panic(fmt.Sprintf("unknown mode: %s", mode))
 	}
+
 	return
 }
 


### PR DESCRIPTION
## Summary

There are no exported string type constants for `RuleType` and the rule types from configuration files right now, developers often needs to explicitly write out and enumerate all the possible rule type, and other iota type when integration with clash and process with configuration files, therefore I added the standalone `RuleConfig` type alone with all the currently supported rule types that exported for better API and DX.

## Changes

- Added `RuleConfig` type and all the enums.
- Added compile-time interface check as this is part of the best practice that mentioned by Uber Golang Guide. [References](https://github.com/uber-go/guide/blob/master/style.md#verify-interface-compliance)
- Added `exhaustive` linter to check whether all the enums are presented in switch branches.