### PR TITLE
Chore: added a new test CI to run unit test and build test for Pull Requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Get dependencies, run test
-        run: |
-          go test ./...
-
       - name: Build
         if: startsWith(github.ref, 'refs/tags/')
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version: '1.21'
+          go-version: "1.21"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version: '1.21'
+          go-version: "1.21"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -57,4 +57,4 @@ jobs:
         env:
           NAME: clash
           BINDIR: bin
-        run: make -j $(go run ./test/main.go) all-arch
+        run: make -j $(go run ./test/main.go) all

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version: "1.21"
+          go-version: '1.21'
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version: "1.21"
+          go-version: '1.21'
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,58 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          check-latest: true
+          go-version: '1.21'
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Cache go module
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Get dependencies, run test
+        run: |
+          go test ./...
+
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          check-latest: true
+          go-version: '1.21'
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Cache go module
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        env:
+          NAME: clash
+          BINDIR: bin
+        run: make -j $(go run ./test/main.go) all-arch

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
@@ -29,7 +30,8 @@ jobs:
         run: |
           go test ./...
 
-  test-build:
+  build-test:
+    name: Build Test
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,10 @@ linux-mips64le:
 	GOARCH=mips64le GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
 
 linux-riscv64:
-	GOARCH=riscv64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@	
+	GOARCH=riscv64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
 
 linux-loong64:
-	GOARCH=loong64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@	
+	GOARCH=loong64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
 
 freebsd-386:
 	GOARCH=386 GOOS=freebsd $(GOBUILD) -o $(BINDIR)/$(NAME)-$@

--- a/rule/parser_test.go
+++ b/rule/parser_test.go
@@ -116,16 +116,18 @@ func TestParseRule(t *testing.T) {
 			expectedRule: lo.Must(NewProcess("/opt/example/example", policy, false)),
 		},
 		{
-			tp:           C.RuleConfigIPSet,
-			payload:      "example",
-			target:       policy,
-			expectedRule: lo.Must(NewIPSet("example", policy, true)),
+			tp:      C.RuleConfigIPSet,
+			payload: "example",
+			target:  policy,
+			// unit test runs on Linux machine and NewIPSet(...) won't be available
+			expectedError: errors.New("operation not permitted"),
 		},
 		{
 			tp:      C.RuleConfigIPSet,
 			payload: "example",
 			target:  policy, params: []string{noResolve},
-			expectedRule: lo.Must(NewIPSet("example", policy, false)),
+			// unit test runs on Linux machine and NewIPSet(...) won't be available
+			expectedError: errors.New("operation not permitted"),
 		},
 		{
 			tp:           C.RuleConfigMatch,


### PR DESCRIPTION
## Summary

1. It looks like the previous merged PR cause the GitHub Actions `Get dependencies, run test` step in `build` job for `Release` workflow failed to run, and this repository is missing a unit test and build test CI when collaborate within Pull Request.
2. In order to properly fix the failed test and or help the collaborative developers get the insights of their committed codes with CI/CD provided GitHub Actions, this Pull Request proposed to setup a standalone CI that triggers on `push` and `pull_request`.