### PR TITLE
Fix: DNS NCACHE TTL and OPT RRs

### DIFF
--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -14,9 +14,9 @@ import (
 	"github.com/Dreamacro/clash/component/resolver"
 	"github.com/Dreamacro/clash/component/trie"
 	C "github.com/Dreamacro/clash/constant"
-	"github.com/samber/lo"
 
 	D "github.com/miekg/dns"
+	"github.com/samber/lo"
 	"golang.org/x/sync/singleflight"
 )
 

--- a/dns/resolver.go
+++ b/dns/resolver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dreamacro/clash/component/resolver"
 	"github.com/Dreamacro/clash/component/trie"
 	C "github.com/Dreamacro/clash/constant"
+	"github.com/samber/lo"
 
 	D "github.com/miekg/dns"
 	"golang.org/x/sync/singleflight"
@@ -166,7 +167,10 @@ func (r *Resolver) exchangeWithoutCache(ctx context.Context, m *D.Msg) (msg *D.M
 			}
 
 			msg := result.(*D.Msg)
-
+			// OPT RRs MUST NOT be cached, forwarded, or stored in or loaded from master files.
+			msg.Extra = lo.Filter(msg.Extra, func(rr D.RR, index int) bool {
+				return rr.Header().Rrtype != D.TypeOPT
+			})
 			putMsgToCache(r.lruCache, q.String(), q, msg)
 		}()
 


### PR DESCRIPTION
1. DNS NCACHE was not correctly implemented.
2. OPT RRs must not be cached or forwarded.

Closes #2889.

---

Open question: Should we reintroduce the hack of bypassing caches for ACME challenge RRs?

https://github.com/Dreamacro/clash/blob/c1d027d6d1e6b9db7205ad74a4554c96822110bb/dns/util.go#L37-L41

I'm not sure why we would need this workaround. It appears that the RRs will be cached by the upstream servers regardless.