### PR TITLE
Feat: add `REJECT-DROP`

### DIFF
--- a/adapter/outbound/reject.go
+++ b/adapter/outbound/reject.go
@@ -12,35 +12,51 @@ import (
 
 type Reject struct {
 	*Base
+	drop bool
 }
 
 // DialContext implements C.ProxyAdapter
 func (r *Reject) DialContext(ctx context.Context, metadata *C.Metadata, opts ...dialer.Option) (C.Conn, error) {
-	return NewConn(&nopConn{}, r), nil
+	return NewConn(&nopConn{r.drop}, r), nil
 }
 
 // ListenPacketContext implements C.ProxyAdapter
 func (r *Reject) ListenPacketContext(ctx context.Context, metadata *C.Metadata, opts ...dialer.Option) (C.PacketConn, error) {
-	return newPacketConn(&nopPacketConn{}, r), nil
+	return newPacketConn(&nopPacketConn{r.drop}, r), nil
 }
 
-func NewReject() *Reject {
+func NewReject(drop bool) *Reject {
+	var name string
+	if drop {
+		name = "REJECT-DROP"
+	} else {
+		name = "REJECT"
+	}
 	return &Reject{
 		Base: &Base{
-			name: "REJECT",
+			name: name,
 			tp:   C.Reject,
 			udp:  true,
 		},
+		drop: drop,
 	}
 }
 
-type nopConn struct{}
+type nopConn struct {
+	drop bool
+}
 
 func (rw *nopConn) Read(b []byte) (int, error) {
+	if rw.drop {
+		time.Sleep(C.DefaultRejectDropTimeout)
+	}
 	return 0, io.EOF
 }
 
 func (rw *nopConn) Write(b []byte) (int, error) {
+	if rw.drop {
+		time.Sleep(C.DefaultRejectDropTimeout)
+	}
 	return 0, io.EOF
 }
 
@@ -51,12 +67,26 @@ func (rw *nopConn) SetDeadline(time.Time) error      { return nil }
 func (rw *nopConn) SetReadDeadline(time.Time) error  { return nil }
 func (rw *nopConn) SetWriteDeadline(time.Time) error { return nil }
 
-type nopPacketConn struct{}
+type nopPacketConn struct {
+	drop bool
+}
 
-func (npc *nopPacketConn) WriteTo(b []byte, addr net.Addr) (n int, err error) { return len(b), nil }
-func (npc *nopPacketConn) ReadFrom(b []byte) (int, net.Addr, error)           { return 0, nil, io.EOF }
-func (npc *nopPacketConn) Close() error                                       { return nil }
-func (npc *nopPacketConn) LocalAddr() net.Addr                                { return &net.UDPAddr{IP: net.IPv4zero, Port: 0} }
-func (npc *nopPacketConn) SetDeadline(time.Time) error                        { return nil }
-func (npc *nopPacketConn) SetReadDeadline(time.Time) error                    { return nil }
-func (npc *nopPacketConn) SetWriteDeadline(time.Time) error                   { return nil }
+func (npc *nopPacketConn) WriteTo(b []byte, addr net.Addr) (n int, err error) {
+	if npc.drop {
+		time.Sleep(C.DefaultRejectDropTimeout)
+	}
+	return len(b), nil
+}
+
+func (npc *nopPacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	if npc.drop {
+		time.Sleep(C.DefaultRejectDropTimeout)
+	}
+	return 0, nil, io.EOF
+}
+
+func (npc *nopPacketConn) Close() error                     { return nil }
+func (npc *nopPacketConn) LocalAddr() net.Addr              { return &net.UDPAddr{IP: net.IPv4zero, Port: 0} }
+func (npc *nopPacketConn) SetDeadline(time.Time) error      { return nil }
+func (npc *nopPacketConn) SetReadDeadline(time.Time) error  { return nil }
+func (npc *nopPacketConn) SetWriteDeadline(time.Time) error { return nil }

--- a/adapter/provider/provider.go
+++ b/adapter/provider/provider.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var reject = adapter.NewProxy(outbound.NewReject())
+var reject = adapter.NewProxy(outbound.NewReject(false))
 
 const (
 	ReservedName = "default"

--- a/config/config.go
+++ b/config/config.go
@@ -360,8 +360,9 @@ func parseProxies(cfg *RawConfig) (proxies map[string]C.Proxy, providersMap map[
 	providersConfig := cfg.ProxyProvider
 
 	proxies["DIRECT"] = adapter.NewProxy(outbound.NewDirect())
-	proxies["REJECT"] = adapter.NewProxy(outbound.NewReject())
-	proxyList = append(proxyList, "DIRECT", "REJECT")
+	proxies["REJECT"] = adapter.NewProxy(outbound.NewReject(false))
+	proxies["REJECT-DROP"] = adapter.NewProxy(outbound.NewReject(true))
+	proxyList = append(proxyList, "DIRECT", "REJECT", "REJECT-DROP")
 
 	// parse proxy
 	for idx, mapping := range proxiesConfig {

--- a/constant/adapters.go
+++ b/constant/adapters.go
@@ -31,9 +31,10 @@ const (
 )
 
 const (
-	DefaultTCPTimeout = 5 * time.Second
-	DefaultUDPTimeout = DefaultTCPTimeout
-	DefaultTLSTimeout = DefaultTCPTimeout
+	DefaultTCPTimeout        = 5 * time.Second
+	DefaultRejectDropTimeout = 30 * time.Second
+	DefaultUDPTimeout        = DefaultTCPTimeout
+	DefaultTLSTimeout        = DefaultTCPTimeout
 )
 
 type Connection interface {

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -469,6 +469,7 @@ rules:
   - DOMAIN-KEYWORD,google,auto
   - DOMAIN,google.com,auto
   - DOMAIN-SUFFIX,ad.com,REJECT
+  - DOMAIN-SUFFIX,ad.com,REJECT-DROP
   - SRC-IP-CIDR,192.168.1.201/32,DIRECT
   # optional param "no-resolve" for IP rules (GEOIP, IP-CIDR, IP-CIDR6)
   - IP-CIDR,127.0.0.0/8,DIRECT

--- a/docs/configuration/rules.md
+++ b/docs/configuration/rules.md
@@ -17,10 +17,11 @@ The `no-resolve` option is optional, and it's used to skip DNS resolution for th
 
 ## Policy
 
-There are four types of POLICY for now, in which:
+There are five types of POLICY for now, in which:
 
 - DIRECT: directly connects to the target through `interface-name` (does not lookup system route table)
 - REJECT: drops the packet
+- REJECT-DROP: drops the packet but does not close the connection, instead waits for the client to timeout, to deal with request storms from certain applications
 - Proxy: routes the packet to the specified proxy server
 - Proxy Group: routes the packet to the specified proxy group
 

--- a/docs/zh_CN/configuration/configuration-reference.md
+++ b/docs/zh_CN/configuration/configuration-reference.md
@@ -465,6 +465,7 @@ rules:
   - DOMAIN-KEYWORD,google,auto
   - DOMAIN,google.com,auto
   - DOMAIN-SUFFIX,ad.com,REJECT
+  - DOMAIN-SUFFIX,ad.com,REJECT-DROP
   - SRC-IP-CIDR,192.168.1.201/32,DIRECT
   # 用于 IP 规则 (GEOIP, IP-CIDR, IP-CIDR6) 的可选参数 "no-resolve"
   - IP-CIDR,127.0.0.0/8,DIRECT

--- a/docs/zh_CN/configuration/rules.md
+++ b/docs/zh_CN/configuration/rules.md
@@ -18,10 +18,11 @@ TYPE,ARGUMENT,POLICY(,no-resolve)
 
 ## 策略
 
-目前有四种策略类型, 其中:
+目前有五种策略类型, 其中:
 
 - DIRECT: 通过 `interface-name` 直接连接到目标 (不查找系统路由表)
 - REJECT: 丢弃数据包
+- REJECT-DROP: 丢弃数据包但并不关闭连接，而是等待客户端超时，以应对某些应用产生的请求风暴
 - Proxy: 将数据包路由到指定的代理服务器
 - Proxy Group: 将数据包路由到指定的策略组
 


### PR DESCRIPTION
Just like `REJECT-DROP` in [Surge](https://kb.nssurge.com/surge-knowledge-base/technotes/reject), default timeout 30s.

Simple config example:

```yaml
mixed-port: 7890

rules:
  - MATCH,REJECT-DROP
```

Test by `curl`:

```shell
$ time curl baidu.com -vvv
* Uses proxy env variable http_proxy == 'http://127.0.0.1:7890'
*   Trying 127.0.0.1:7890...
* Connected to 127.0.0.1 (127.0.0.1) port 7890
> GET http://baidu.com/ HTTP/1.1
> Host: baidu.com
> User-Agent: curl/8.4.0
> Accept: */*
> Proxy-Connection: Keep-Alive
>
< HTTP/1.1 502 Bad Gateway
< Connection: keep-alive
< Keep-Alive: timeout=4
< Proxy-Connection: keep-alive
< Content-Length: 0
<
* Connection #0 to host 127.0.0.1 left intact
curl baidu.com -vvv  0.00s user 0.00s system 0% cpu 30.058 total
```

Log:

```log
time="2023-10-15T10:37:33+08:00" level=info msg="[TCP] 127.0.0.1:5558 --> baidu.com:80 match Match() using REJECT-DROP"
```
